### PR TITLE
feat(demo): Add A2A demo with AEX discovery integration

### DIFF
--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,0 +1,17 @@
+# API Key for LLM provider
+# Claude - used by all agents (A, B, C) and Orchestrator
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# AEX Configuration
+AEX_GATEWAY_URL=http://localhost:8080
+
+# Agent Ports (optional, defaults in config.yaml)
+# Legal Agents with tiered pricing:
+#   A (Budget):   $5 base + $2/page   - Best for 1-5 pages
+#   B (Standard): $15 base + $0.50/page - Best for 5-30 pages
+#   C (Premium):  $30 base + $0.20/page - Best for 30+ pages
+LEGAL_AGENT_A_PORT=8100
+LEGAL_AGENT_B_PORT=8101
+LEGAL_AGENT_C_PORT=8102
+ORCHESTRATOR_PORT=8103
+DEMO_UI_PORT=8501

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,336 @@
+# Agent Exchange - A2A Integration Demo
+
+This directory contains demo agents and a UI showcasing the integration between Agent Exchange (AEX) and the A2A Protocol. The demo features **three legal agents with tiered pricing** to demonstrate AEX's intelligent bid evaluation and selection.
+
+## Overview
+
+```
+demo/
+├── agents/
+│   ├── common/              # Shared utilities for all agents
+│   ├── legal-agent-a/       # Budget tier - Claude (fast, basic analysis)
+│   ├── legal-agent-b/       # Standard tier - Claude (thorough analysis)
+│   ├── legal-agent-c/       # Premium tier - Claude (exhaustive expert analysis)
+│   └── orchestrator/        # Consumer agent that coordinates work
+├── ui/                      # Mesop web interface
+├── docker-compose.yml       # Run all demo components
+└── README.md
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              DEMO FLOW                                       │
+│                                                                             │
+│  User ──► Mesop UI ──► Orchestrator ──► Agent Exchange ──► Provider Agents │
+│                              │                                   │          │
+│                              │         (Discovery, Bidding)      │          │
+│                              │                                   │          │
+│                              └───────────── A2A ─────────────────┘          │
+│                                      (Direct Execution)                     │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Agents
+
+### Legal Agents with Tiered Pricing
+
+| Agent | Tier | LLM | Pricing | Best For | Port |
+|-------|------|-----|---------|----------|------|
+| **Legal Agent A** | Budget | Claude | $5 + $2/page | Short docs (1-5 pages) | 8100 |
+| **Legal Agent B** | Standard | Claude | $15 + $0.50/page | Medium docs (5-30 pages) | 8101 |
+| **Legal Agent C** | Premium | Claude | $30 + $0.20/page | Large docs (30+ pages) | 8102 |
+
+### Pricing Examples
+
+| Document Size | Agent A (Budget) | Agent B (Standard) | Agent C (Premium) | Best Choice |
+|---------------|------------------|--------------------|--------------------|-------------|
+| 3 pages | $11 | $16.50 | $30.60 | **Agent A** |
+| 10 pages | $25 | $20 | $32 | **Agent B** |
+| 20 pages | $45 | $25 | $34 | **Agent B** |
+| 50 pages | $105 | $40 | $40 | **Agent B/C** |
+| 100 pages | $205 | $65 | $50 | **Agent C** |
+
+### Other Services
+
+| Agent | LLM | Framework | Purpose | Port |
+|-------|-----|-----------|---------|------|
+| **Orchestrator** | Claude | LangGraph | Task decomposition, AEX integration | 8103 |
+| **Demo UI** | - | Mesop | Web interface | 8501 |
+
+## Quick Start
+
+### Prerequisites
+
+- Docker & Docker Compose
+- Python 3.11+
+- API Key: `ANTHROPIC_API_KEY`
+
+> **Note**: No GPU required! All agents use Anthropic Claude API. Your machine only runs lightweight Python servers that make API calls.
+
+### Run the Demo
+
+```bash
+# From project root
+cd demo
+
+# Set your API key
+cp .env.example .env
+# Edit .env with your Anthropic API key
+
+# Start everything (AEX system + Demo agents + UI)
+docker-compose up --build
+
+# Access the demo
+open http://localhost:8501
+```
+
+This single command builds and starts:
+- All AEX core services (Gateway, Provider Registry, Bid Gateway, etc.)
+- MongoDB database
+- 3 Legal Agents (Budget, Standard, Premium)
+- Orchestrator
+- Demo UI
+
+### Run Locally (Development)
+
+```bash
+# Terminal 1: Start AEX services
+cd .. && make docker-up
+
+# Terminal 2: Start Legal Agent A (Budget)
+cd agents/legal-agent-a
+pip install -r requirements.txt
+python main.py
+
+# Terminal 3: Start Legal Agent B (Standard)
+cd agents/legal-agent-b
+pip install -r requirements.txt
+python main.py
+
+# Terminal 4: Start Legal Agent C (Premium)
+cd agents/legal-agent-c
+pip install -r requirements.txt
+python main.py
+
+# Terminal 5: Start Demo UI
+cd ui
+pip install -r requirements.txt
+mesop main.py
+```
+
+## Demo Scenario
+
+**User Request**:
+> "Review this 15-page partnership agreement and identify all risks and obligations."
+
+**What Happens**:
+
+1. **Orchestrator** analyzes request, identifies task:
+   - Contract Review → requires `contract_review` skill
+   - Document: 15 pages
+
+2. **AEX Discovery**:
+   ```
+   GET /v1/providers/search?skill_tag=contract_review
+   → Found: Legal Agent A (Budget), Legal Agent B (Standard), Legal Agent C (Premium)
+   ```
+
+3. **Bidding** (document-aware pricing):
+   ```
+   Legal Agent A (Budget):   $5 + (15 × $2)    = $35, confidence 75%
+   Legal Agent B (Standard): $15 + (15 × $0.50) = $22.50, confidence 88%
+   Legal Agent C (Premium):  $30 + (15 × $0.20) = $33, confidence 95%
+   ```
+
+4. **Evaluation** (balanced strategy):
+   ```
+   Score = 0.3×price + 0.3×trust + 0.15×confidence + 0.15×quality + 0.1×SLA
+
+   Agent A: Low price but lower confidence → Score: 0.72
+   Agent B: Best price/quality balance    → Score: 0.85 ← Winner
+   Agent C: High confidence but pricier   → Score: 0.81
+   ```
+
+5. **A2A Execution**:
+   ```
+   POST https://legal-agent-b:8101/a2a
+   Authorization: Bearer {contract_token}
+   {"jsonrpc":"2.0","method":"message/send",...}
+   ```
+
+6. **Settlement**:
+   ```
+   Total: $22.50
+   Platform Fee (15%): $3.38
+   Provider Payout: $19.12
+   ```
+
+### Document Size Impact
+
+For a **100-page contract**, selection would differ:
+```
+Legal Agent A: $5 + (100 × $2)    = $205 ← Too expensive
+Legal Agent B: $15 + (100 × $0.50) = $65
+Legal Agent C: $30 + (100 × $0.20) = $50  ← Best value
+```
+
+## Configuration
+
+### Agent Configuration
+
+Each agent has a `config.yaml` with tiered pricing:
+
+```yaml
+# agents/legal-agent-a/config.yaml (Budget Tier)
+agent:
+  name: "Budget Legal AI"
+  description: "Fast, affordable contract review - basic analysis at low cost"
+  version: "1.0.0"
+
+server:
+  host: "0.0.0.0"
+  port: 8100
+
+llm:
+  provider: "anthropic"
+  model: "claude-sonnet-4-20250514"
+  temperature: 0.5
+
+characteristics:
+  tier: "budget"
+  response_style: "concise"
+  detail_level: "basic"
+  turnaround: "fast"
+
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Quick contract review highlighting major issues"
+    tags: ["legal", "contracts", "review"]
+
+aex:
+  enabled: true
+  gateway_url: "http://localhost:8080"
+  auto_register: true
+  auto_bid: true
+  pricing:
+    base_rate: 5.00
+    per_page_rate: 2.00
+    max_pages_optimal: 5
+    currency: "USD"
+    description: "Best for quick reviews of short documents (1-5 pages)"
+  bidding:
+    confidence: 0.75
+    estimated_time_minutes: 3
+    max_document_pages: 10
+```
+
+### Environment Variables
+
+```bash
+# .env
+# Claude - used by all agents
+ANTHROPIC_API_KEY=sk-ant-...
+
+# AEX Configuration
+AEX_GATEWAY_URL=http://localhost:8080
+
+# Agent Ports
+LEGAL_AGENT_A_PORT=8100  # Budget: $5 + $2/page
+LEGAL_AGENT_B_PORT=8101  # Standard: $15 + $0.50/page
+LEGAL_AGENT_C_PORT=8102  # Premium: $30 + $0.20/page
+ORCHESTRATOR_PORT=8103
+```
+
+## API Endpoints
+
+### Agent Card (A2A Standard)
+
+```bash
+# Get agent capabilities
+curl http://localhost:8100/.well-known/agent-card.json
+```
+
+### A2A JSON-RPC
+
+```bash
+# Send message to agent
+curl -X POST http://localhost:8100/a2a \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer {token}" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "message/send",
+    "id": "1",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "Review this contract..."}]
+      }
+    }
+  }'
+```
+
+## Development
+
+### Adding a New Agent
+
+1. Copy an existing agent folder:
+   ```bash
+   cp -r agents/legal-agent-a agents/my-new-agent
+   ```
+
+2. Update `config.yaml` with new skills
+
+3. Implement skill handlers in `skills/`
+
+4. Update `docker-compose.yml`
+
+5. Register with AEX
+
+### Testing
+
+```bash
+# Test individual agent
+cd agents/legal-agent-a
+pytest tests/ -v
+
+# Test full demo flow
+cd demo
+python scripts/test_e2e.py
+```
+
+## Troubleshooting
+
+### Agent not discovered by AEX
+
+1. Check agent is registered:
+   ```bash
+   curl http://localhost:8080/v1/providers
+   ```
+
+2. Verify agent card is accessible:
+   ```bash
+   curl http://localhost:8100/.well-known/agent-card.json
+   ```
+
+### Bidding not working
+
+1. Check agent has `auto_bid: true` in config
+2. Verify AEX gateway URL is correct
+3. Check agent logs for errors
+
+### A2A execution fails
+
+1. Verify contract token is valid
+2. Check agent is accepting the token
+3. Review agent logs for authentication errors
+
+## Related Documentation
+
+- [A2A Integration Roadmap](../documents/a2a-integration/AEX_A2A_INTEGRATION_ROADMAP.md)
+- [Value Proposition](../documents/a2a-integration/AEX_A2A_VALUE_PROPOSITION.md)
+- [Call Flow Diagrams](../documents/a2a-integration/diagrams/)

--- a/demo/agents/Dockerfile
+++ b/demo/agents/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+ARG AGENT_DIR
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy common utilities first
+COPY common/ /app/common/
+
+# Install common dependencies first
+RUN pip install --no-cache-dir -r /app/common/requirements.txt
+
+# Copy agent-specific files
+COPY ${AGENT_DIR}/ /app/
+
+# Install agent-specific dependencies (skip the -r ../common/requirements.txt line)
+RUN grep -v "^-r " requirements.txt > agent_requirements.txt || true && \
+    pip install --no-cache-dir -r agent_requirements.txt || true
+
+# Run the agent
+CMD ["python", "main.py"]

--- a/demo/agents/common/__init__.py
+++ b/demo/agents/common/__init__.py
@@ -1,0 +1,18 @@
+"""Common utilities for AEX demo agents."""
+
+from .a2a_server import A2AServer, A2AHandler
+from .aex_client import AEXClient
+from .agent_card import AgentCard, Skill, Provider, Capabilities
+from .config import AgentConfig, load_config
+
+__all__ = [
+    "A2AServer",
+    "A2AHandler",
+    "AEXClient",
+    "AgentCard",
+    "Skill",
+    "Provider",
+    "Capabilities",
+    "AgentConfig",
+    "load_config",
+]

--- a/demo/agents/common/a2a_server.py
+++ b/demo/agents/common/a2a_server.py
@@ -1,0 +1,279 @@
+"""A2A Protocol server implementation."""
+
+import asyncio
+import json
+import logging
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, AsyncIterator, Callable, Optional
+from aiohttp import web
+
+from .agent_card import AgentCard
+
+logger = logging.getLogger(__name__)
+
+
+class TaskState(str, Enum):
+    """A2A Task states."""
+    SUBMITTED = "submitted"
+    WORKING = "working"
+    INPUT_REQUIRED = "input-required"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+    FAILED = "failed"
+
+
+@dataclass
+class Message:
+    """A2A Message."""
+    role: str  # "user" or "agent"
+    parts: list[dict]
+    messageId: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    @classmethod
+    def text(cls, role: str, text: str) -> "Message":
+        """Create a text message."""
+        return cls(role=role, parts=[{"type": "text", "text": text}])
+
+
+@dataclass
+class Task:
+    """A2A Task."""
+    id: str
+    sessionId: str
+    status: dict
+    history: list[Message] = field(default_factory=list)
+    artifacts: list[dict] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "sessionId": self.sessionId,
+            "status": self.status,
+            "history": [
+                {
+                    "role": m.role,
+                    "parts": m.parts,
+                    "messageId": m.messageId,
+                }
+                for m in self.history
+            ],
+            "artifacts": self.artifacts,
+            "metadata": self.metadata,
+        }
+
+
+class A2AHandler(ABC):
+    """Abstract handler for A2A requests."""
+
+    @abstractmethod
+    async def handle_message(
+        self,
+        task_id: str,
+        session_id: str,
+        message: Message,
+        context: dict,
+    ) -> AsyncIterator[dict]:
+        """
+        Handle an incoming message and yield response events.
+
+        Yields status updates and final result:
+        - {"type": "status", "state": "working", "message": "Processing..."}
+        - {"type": "artifact", "name": "result.txt", "parts": [...]}
+        - {"type": "result", "parts": [...]}
+        """
+        yield {"type": "status", "state": "working"}
+
+    async def validate_token(self, token: str) -> Optional[dict]:
+        """
+        Validate contract token from AEX.
+        Returns token claims if valid, None if invalid.
+        Override this method to implement token validation.
+        """
+        # For demo, accept all tokens
+        return {"contract_id": "demo", "valid": True}
+
+
+class A2AServer:
+    """A2A Protocol compliant server."""
+
+    def __init__(
+        self,
+        agent_card: AgentCard,
+        handler: A2AHandler,
+        require_auth: bool = False,
+    ):
+        self.agent_card = agent_card
+        self.handler = handler
+        self.require_auth = require_auth
+        self.tasks: dict[str, Task] = {}
+        self.app = web.Application()
+        self._setup_routes()
+
+    def _setup_routes(self):
+        """Setup HTTP routes."""
+        self.app.router.add_get("/.well-known/agent-card.json", self._handle_agent_card)
+        self.app.router.add_post("/a2a", self._handle_jsonrpc)
+        self.app.router.add_get("/health", self._handle_health)
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        """Health check endpoint."""
+        return web.json_response({"status": "healthy", "agent": self.agent_card.name})
+
+    async def _handle_agent_card(self, request: web.Request) -> web.Response:
+        """Serve the agent card."""
+        return web.json_response(self.agent_card.to_dict())
+
+    async def _handle_jsonrpc(self, request: web.Request) -> web.Response:
+        """Handle A2A JSON-RPC requests."""
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            return self._error_response(None, -32700, "Parse error")
+
+        # Validate JSON-RPC structure
+        if body.get("jsonrpc") != "2.0":
+            return self._error_response(body.get("id"), -32600, "Invalid Request")
+
+        method = body.get("method")
+        params = body.get("params", {})
+        request_id = body.get("id")
+
+        # Validate auth if required
+        if self.require_auth:
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                return self._error_response(request_id, -32001, "Unauthorized")
+            token = auth_header[7:]
+            claims = await self.handler.validate_token(token)
+            if not claims:
+                return self._error_response(request_id, -32001, "Invalid token")
+            params["_auth"] = claims
+
+        # Route to handler
+        handlers = {
+            "message/send": self._handle_message_send,
+            "message/stream": self._handle_message_stream,
+            "tasks/get": self._handle_tasks_get,
+            "tasks/cancel": self._handle_tasks_cancel,
+        }
+
+        handler_fn = handlers.get(method)
+        if not handler_fn:
+            return self._error_response(request_id, -32601, f"Method not found: {method}")
+
+        try:
+            result = await handler_fn(params)
+            return web.json_response({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": result,
+            })
+        except Exception as e:
+            logger.exception(f"Error handling {method}")
+            return self._error_response(request_id, -32603, str(e))
+
+    async def _handle_message_send(self, params: dict) -> dict:
+        """Handle message/send - synchronous message handling."""
+        message_data = params.get("message", {})
+        session_id = params.get("sessionId", str(uuid.uuid4()))
+
+        # Create message
+        message = Message(
+            role=message_data.get("role", "user"),
+            parts=message_data.get("parts", []),
+            messageId=message_data.get("messageId", str(uuid.uuid4())),
+        )
+
+        # Create or get task
+        task_id = str(uuid.uuid4())
+        task = Task(
+            id=task_id,
+            sessionId=session_id,
+            status={"state": TaskState.SUBMITTED.value},
+            history=[message],
+        )
+        self.tasks[task_id] = task
+
+        # Process message
+        context = params.get("_auth", {})
+        response_parts = []
+        artifacts = []
+
+        async for event in self.handler.handle_message(task_id, session_id, message, context):
+            if event["type"] == "status":
+                task.status = {"state": event["state"], "message": event.get("message")}
+            elif event["type"] == "artifact":
+                artifacts.append({
+                    "name": event.get("name", "result"),
+                    "parts": event.get("parts", []),
+                })
+            elif event["type"] == "result":
+                response_parts = event.get("parts", [])
+
+        # Update task
+        task.status = {"state": TaskState.COMPLETED.value}
+        task.artifacts = artifacts
+
+        # Add agent response to history
+        if response_parts:
+            agent_message = Message(role="agent", parts=response_parts)
+            task.history.append(agent_message)
+
+        return task.to_dict()
+
+    async def _handle_message_stream(self, params: dict) -> dict:
+        """Handle message/stream - streaming message handling."""
+        # For simplicity, delegate to send and return task reference
+        # Real streaming would use SSE
+        result = await self._handle_message_send(params)
+        return result
+
+    async def _handle_tasks_get(self, params: dict) -> dict:
+        """Get task status."""
+        task_id = params.get("id")
+        if not task_id or task_id not in self.tasks:
+            raise ValueError(f"Task not found: {task_id}")
+        return self.tasks[task_id].to_dict()
+
+    async def _handle_tasks_cancel(self, params: dict) -> dict:
+        """Cancel a task."""
+        task_id = params.get("id")
+        if not task_id or task_id not in self.tasks:
+            raise ValueError(f"Task not found: {task_id}")
+        task = self.tasks[task_id]
+        task.status = {"state": TaskState.CANCELED.value}
+        return task.to_dict()
+
+    def _error_response(self, request_id: Any, code: int, message: str) -> web.Response:
+        """Create JSON-RPC error response."""
+        return web.json_response({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        })
+
+    async def run_async(self, host: str = "0.0.0.0", port: int = 8100):
+        """Run the server asynchronously."""
+        logger.info(f"Starting A2A server at http://{host}:{port}")
+        logger.info(f"Agent Card: http://{host}:{port}/.well-known/agent-card.json")
+        runner = web.AppRunner(self.app)
+        await runner.setup()
+        site = web.TCPSite(runner, host, port)
+        await site.start()
+        # Keep running until interrupted
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            await runner.cleanup()
+
+    def run(self, host: str = "0.0.0.0", port: int = 8100):
+        """Run the server synchronously."""
+        logger.info(f"Starting A2A server at http://{host}:{port}")
+        logger.info(f"Agent Card: http://{host}:{port}/.well-known/agent-card.json")
+        web.run_app(self.app, host=host, port=port)

--- a/demo/agents/common/aex_client.py
+++ b/demo/agents/common/aex_client.py
@@ -1,0 +1,286 @@
+"""AEX (Agent Exchange) client for demo agents."""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Optional
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BidRequest:
+    """Incoming bid request from AEX."""
+    work_id: str
+    domain: str
+    requirements: dict
+    budget: dict
+    deadline_ms: int
+
+
+@dataclass
+class BidResponse:
+    """Bid response to submit to AEX."""
+    work_id: str
+    price: float
+    currency: str = "USD"
+    confidence: float = 0.9
+    estimated_duration_ms: int = 60000
+    metadata: Optional[dict] = None
+
+
+@dataclass
+class ContractAward:
+    """Contract award notification from AEX."""
+    contract_id: str
+    work_id: str
+    consumer_id: str
+    agreed_price: float
+    cpa_terms: Optional[dict] = None
+    token: str = ""
+
+
+class AEXClient:
+    """Client for interacting with Agent Exchange."""
+
+    def __init__(
+        self,
+        gateway_url: str,
+        provider_id: Optional[str] = None,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ):
+        self.gateway_url = gateway_url.rstrip("/")
+        self.provider_id = provider_id
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create HTTP session."""
+        if self._session is None or self._session.closed:
+            headers = {}
+            if self.api_key:
+                headers["X-API-Key"] = self.api_key
+            if self.api_secret:
+                headers["X-API-Secret"] = self.api_secret
+            self._session = aiohttp.ClientSession(headers=headers)
+        return self._session
+
+    async def close(self):
+        """Close the client session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def register_provider(
+        self,
+        name: str,
+        description: str,
+        endpoint: str,
+        bid_webhook: str,
+        capabilities: list[str],
+        contact_email: str = "",
+    ) -> dict:
+        """Register as a provider with AEX."""
+        session = await self._get_session()
+        payload = {
+            "name": name,
+            "description": description,
+            "endpoint": endpoint,
+            "bid_webhook": bid_webhook,
+            "capabilities": capabilities,
+            "contact_email": contact_email,
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/providers",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to register provider: {error}")
+            data = await resp.json()
+            self.provider_id = data["provider_id"]
+            self.api_key = data["api_key"]
+            self.api_secret = data["api_secret"]
+            logger.info(f"Registered provider: {self.provider_id}")
+            return data
+
+    async def subscribe_to_categories(
+        self,
+        categories: list[str],
+        webhook_url: Optional[str] = None,
+    ) -> dict:
+        """Subscribe to work categories."""
+        if not self.provider_id:
+            raise ValueError("Provider not registered")
+
+        session = await self._get_session()
+        payload = {
+            "provider_id": self.provider_id,
+            "categories": categories,
+            "filters": {},
+            "delivery": {
+                "method": "webhook" if webhook_url else "polling",
+                "webhook_url": webhook_url or "",
+            },
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/subscriptions",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to create subscription: {error}")
+            data = await resp.json()
+            logger.info(f"Subscribed to categories: {categories}")
+            return data
+
+    async def submit_bid(self, bid: BidResponse) -> dict:
+        """Submit a bid for work."""
+        if not self.provider_id:
+            raise ValueError("Provider not registered")
+
+        session = await self._get_session()
+        payload = {
+            "work_id": bid.work_id,
+            "provider_id": self.provider_id,
+            "price": bid.price,
+            "currency": bid.currency,
+            "confidence": bid.confidence,
+            "estimated_duration_ms": bid.estimated_duration_ms,
+            "metadata": bid.metadata or {},
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/bids",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to submit bid: {error}")
+            data = await resp.json()
+            logger.info(f"Submitted bid for work {bid.work_id}")
+            return data
+
+    async def report_completion(
+        self,
+        contract_id: str,
+        success: bool,
+        metrics: Optional[dict] = None,
+        artifacts: Optional[list] = None,
+    ) -> dict:
+        """Report work completion to AEX for settlement."""
+        session = await self._get_session()
+        payload = {
+            "contract_id": contract_id,
+            "success": success,
+            "metrics": metrics or {},
+            "artifacts": artifacts or [],
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/contracts/{contract_id}/complete",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to report completion: {error}")
+            data = await resp.json()
+            logger.info(f"Reported completion for contract {contract_id}")
+            return data
+
+    async def get_work_details(self, work_id: str) -> dict:
+        """Get details of a work spec."""
+        session = await self._get_session()
+        async with session.get(f"{self.gateway_url}/v1/work/{work_id}") as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to get work details: {error}")
+            return await resp.json()
+
+    async def search_providers(
+        self,
+        skill_tags: Optional[list[str]] = None,
+        domain: Optional[str] = None,
+    ) -> list[dict]:
+        """Search for providers by skill or domain."""
+        session = await self._get_session()
+        params = {}
+        if skill_tags:
+            params["skill_tags"] = ",".join(skill_tags)
+        if domain:
+            params["domain"] = domain
+
+        async with session.get(
+            f"{self.gateway_url}/v1/providers/search",
+            params=params,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to search providers: {error}")
+            data = await resp.json()
+            return data.get("providers", [])
+
+    async def submit_work(
+        self,
+        domain: str,
+        requirements: dict,
+        budget: dict,
+        skill_tags: Optional[list[str]] = None,
+        success_criteria: Optional[list] = None,
+        bid_window_ms: int = 30000,
+    ) -> dict:
+        """Submit work as a consumer."""
+        session = await self._get_session()
+        payload = {
+            "domain": domain,
+            "requirements": requirements,
+            "budget": budget,
+            "skill_tags": skill_tags or [],
+            "success_criteria": success_criteria or [],
+            "bid_window_ms": bid_window_ms,
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/work",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to submit work: {error}")
+            data = await resp.json()
+            logger.info(f"Submitted work: {data.get('work_id')}")
+            return data
+
+    async def get_evaluation(self, work_id: str) -> dict:
+        """Get bid evaluation results."""
+        session = await self._get_session()
+        async with session.get(
+            f"{self.gateway_url}/v1/work/{work_id}/evaluation"
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to get evaluation: {error}")
+            return await resp.json()
+
+    async def award_contract(self, work_id: str, bid_id: str) -> dict:
+        """Award contract to winning bid."""
+        session = await self._get_session()
+        payload = {
+            "work_id": work_id,
+            "bid_id": bid_id,
+        }
+
+        async with session.post(
+            f"{self.gateway_url}/v1/contracts",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise Exception(f"Failed to award contract: {error}")
+            data = await resp.json()
+            logger.info(f"Awarded contract: {data.get('contract_id')}")
+            return data

--- a/demo/agents/common/agent_card.py
+++ b/demo/agents/common/agent_card.py
@@ -1,0 +1,118 @@
+"""A2A Agent Card models and utilities."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Optional
+import json
+
+
+@dataclass
+class Provider:
+    """Agent provider information."""
+    organization: str
+    url: Optional[str] = None
+
+
+@dataclass
+class Capabilities:
+    """Agent capabilities."""
+    streaming: bool = False
+    pushNotifications: bool = False
+    stateTransitionHistory: bool = False
+
+
+@dataclass
+class Skill:
+    """A2A Skill definition."""
+    id: str
+    name: str
+    description: Optional[str] = None
+    tags: list[str] = field(default_factory=list)
+    examples: list[str] = field(default_factory=list)
+    inputModes: list[str] = field(default_factory=lambda: ["text"])
+    outputModes: list[str] = field(default_factory=lambda: ["text"])
+
+
+@dataclass
+class AgentCard:
+    """A2A Agent Card - describes agent capabilities."""
+    name: str
+    description: str
+    url: str
+    version: str
+    skills: list[Skill]
+    provider: Optional[Provider] = None
+    documentationUrl: Optional[str] = None
+    capabilities: Capabilities = field(default_factory=Capabilities)
+    defaultInputModes: list[str] = field(default_factory=lambda: ["text"])
+    defaultOutputModes: list[str] = field(default_factory=lambda: ["text"])
+    authentication: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        result = {
+            "name": self.name,
+            "description": self.description,
+            "url": self.url,
+            "version": self.version,
+            "capabilities": asdict(self.capabilities),
+            "defaultInputModes": self.defaultInputModes,
+            "defaultOutputModes": self.defaultOutputModes,
+            "skills": [asdict(s) for s in self.skills],
+        }
+        if self.provider:
+            result["provider"] = asdict(self.provider)
+        if self.documentationUrl:
+            result["documentationUrl"] = self.documentationUrl
+        if self.authentication:
+            result["authentication"] = self.authentication
+        return result
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AgentCard":
+        """Create AgentCard from dictionary."""
+        skills = [
+            Skill(
+                id=s["id"],
+                name=s["name"],
+                description=s.get("description"),
+                tags=s.get("tags", []),
+                examples=s.get("examples", []),
+                inputModes=s.get("inputModes", ["text"]),
+                outputModes=s.get("outputModes", ["text"]),
+            )
+            for s in data.get("skills", [])
+        ]
+
+        provider = None
+        if "provider" in data and data["provider"]:
+            provider = Provider(
+                organization=data["provider"]["organization"],
+                url=data["provider"].get("url"),
+            )
+
+        capabilities = Capabilities()
+        if "capabilities" in data:
+            caps = data["capabilities"]
+            capabilities = Capabilities(
+                streaming=caps.get("streaming", False),
+                pushNotifications=caps.get("pushNotifications", False),
+                stateTransitionHistory=caps.get("stateTransitionHistory", False),
+            )
+
+        return cls(
+            name=data["name"],
+            description=data["description"],
+            url=data["url"],
+            version=data["version"],
+            skills=skills,
+            provider=provider,
+            documentationUrl=data.get("documentationUrl"),
+            capabilities=capabilities,
+            defaultInputModes=data.get("defaultInputModes", ["text"]),
+            defaultOutputModes=data.get("defaultOutputModes", ["text"]),
+            authentication=data.get("authentication"),
+        )

--- a/demo/agents/common/base_agent.py
+++ b/demo/agents/common/base_agent.py
@@ -1,0 +1,183 @@
+"""Base agent implementation using LangGraph."""
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Optional, TypedDict
+
+from langgraph.graph import StateGraph, END
+
+from .a2a_server import A2AHandler, Message, TaskState
+from .aex_client import AEXClient, BidResponse
+from .config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AgentState(TypedDict):
+    """State for the agent graph."""
+    messages: list[dict]
+    task_id: str
+    session_id: str
+    context: dict
+    result: Optional[str]
+    artifacts: list[dict]
+    status: str
+
+
+@dataclass
+class BaseAgent(A2AHandler, ABC):
+    """Base class for LangGraph-based agents."""
+
+    config: AgentConfig
+    aex_client: Optional[AEXClient] = None
+    _graph: Optional[StateGraph] = None
+
+    def __post_init__(self):
+        """Initialize the agent."""
+        import os
+        self._setup_llm()
+        self._build_graph()
+        if self.config.aex.enabled:
+            self.aex_client = AEXClient(
+                gateway_url=self.config.aex.gateway_url,
+                api_key=os.environ.get("AEX_API_KEY", "dev-api-key"),
+            )
+
+    @abstractmethod
+    def _setup_llm(self):
+        """Setup the LLM client. Override in subclass."""
+        pass
+
+    @abstractmethod
+    def _build_graph(self):
+        """Build the LangGraph workflow. Override in subclass."""
+        pass
+
+    @abstractmethod
+    async def process(self, state: AgentState) -> AgentState:
+        """Process a message through the agent. Override in subclass."""
+        pass
+
+    async def handle_message(
+        self,
+        task_id: str,
+        session_id: str,
+        message: Message,
+        context: dict,
+    ) -> AsyncIterator[dict]:
+        """Handle incoming A2A message."""
+        yield {"type": "status", "state": TaskState.WORKING.value, "message": "Processing request..."}
+
+        # Extract text from message parts
+        text_content = ""
+        for part in message.parts:
+            if part.get("type") == "text":
+                text_content += part.get("text", "")
+
+        # Build initial state
+        state: AgentState = {
+            "messages": [{"role": message.role, "content": text_content}],
+            "task_id": task_id,
+            "session_id": session_id,
+            "context": context,
+            "result": None,
+            "artifacts": [],
+            "status": "working",
+        }
+
+        try:
+            # Process through the graph
+            final_state = await self.process(state)
+
+            # Yield artifacts
+            for artifact in final_state.get("artifacts", []):
+                yield {
+                    "type": "artifact",
+                    "name": artifact.get("name", "result"),
+                    "parts": artifact.get("parts", []),
+                }
+
+            # Yield final result
+            result_text = final_state.get("result", "Processing complete.")
+            yield {
+                "type": "result",
+                "parts": [{"type": "text", "text": result_text}],
+            }
+
+        except Exception as e:
+            logger.exception(f"Error processing message: {e}")
+            yield {
+                "type": "result",
+                "parts": [{"type": "text", "text": f"Error: {str(e)}"}],
+            }
+
+    async def calculate_bid(self, work_id: str, requirements: dict, budget: dict) -> Optional[BidResponse]:
+        """
+        Calculate bid for work request.
+        Override in subclass for custom bidding logic.
+        """
+        if not self.config.aex.auto_bid:
+            return None
+
+        # Default: use base rate with small random variation
+        import random
+        price = self.config.aex.base_rate * (0.9 + random.random() * 0.2)
+
+        return BidResponse(
+            work_id=work_id,
+            price=round(price, 2),
+            currency=self.config.aex.currency,
+            confidence=0.85 + random.random() * 0.1,
+            estimated_duration_ms=30000,
+        )
+
+    async def handle_bid_request(self, bid_request: dict) -> Optional[dict]:
+        """Handle incoming bid request from AEX webhook."""
+        work_id = bid_request.get("work_id")
+        requirements = bid_request.get("requirements", {})
+        budget = bid_request.get("budget", {})
+
+        bid = await self.calculate_bid(work_id, requirements, budget)
+        if bid and self.aex_client:
+            return await self.aex_client.submit_bid(bid)
+        return None
+
+    async def register_with_aex(self, base_url: str):
+        """Register this agent with AEX."""
+        if not self.aex_client or not self.config.aex.auto_register:
+            return
+
+        try:
+            # Register provider
+            await self.aex_client.register_provider(
+                name=self.config.name,
+                description=self.config.description,
+                endpoint=base_url,
+                bid_webhook=f"{base_url}/webhook/bid",
+                capabilities=[s.id for s in self.config.skills],
+            )
+
+            # Subscribe to categories based on skill tags
+            categories = set()
+            for skill in self.config.skills:
+                for tag in skill.tags:
+                    categories.add(tag)
+                    categories.add(f"{tag}/*")
+
+            if categories:
+                await self.aex_client.subscribe_to_categories(
+                    categories=list(categories),
+                    webhook_url=f"{base_url}/webhook/work",
+                )
+
+            logger.info(f"Registered with AEX: {self.config.name}")
+
+        except Exception as e:
+            logger.warning(f"Failed to register with AEX: {e}")
+
+    async def close(self):
+        """Cleanup resources."""
+        if self.aex_client:
+            await self.aex_client.close()

--- a/demo/agents/common/config.py
+++ b/demo/agents/common/config.py
@@ -1,0 +1,118 @@
+"""Configuration management for demo agents."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+import os
+import yaml
+
+from .agent_card import AgentCard, Skill, Provider, Capabilities
+
+
+@dataclass
+class LLMConfig:
+    """LLM configuration."""
+    provider: str  # anthropic, openai, google
+    model: str
+    temperature: float = 0.7
+    max_tokens: int = 4096
+
+
+@dataclass
+class ServerConfig:
+    """Server configuration."""
+    host: str = "0.0.0.0"
+    port: int = 8100
+
+
+@dataclass
+class AEXConfig:
+    """AEX integration configuration."""
+    enabled: bool = True
+    gateway_url: str = "http://localhost:8080"
+    auto_register: bool = True
+    auto_bid: bool = True
+    base_rate: float = 25.0
+    currency: str = "USD"
+
+
+@dataclass
+class AgentConfig:
+    """Complete agent configuration."""
+    name: str
+    description: str
+    version: str
+    server: ServerConfig = field(default_factory=ServerConfig)
+    llm: LLMConfig = field(default_factory=lambda: LLMConfig(provider="anthropic", model="claude-3-5-sonnet-20241022"))
+    aex: AEXConfig = field(default_factory=AEXConfig)
+    skills: list[Skill] = field(default_factory=list)
+    provider: Optional[Provider] = None
+
+    def get_agent_card(self, base_url: str) -> AgentCard:
+        """Generate A2A Agent Card from config."""
+        return AgentCard(
+            name=self.name,
+            description=self.description,
+            url=base_url,
+            version=self.version,
+            provider=self.provider,
+            capabilities=Capabilities(streaming=True),
+            skills=self.skills,
+        )
+
+
+def load_config(config_path: str = "config.yaml") -> AgentConfig:
+    """Load agent configuration from YAML file."""
+    with open(config_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    agent_data = data.get("agent", {})
+    server_data = data.get("server", {})
+    llm_data = data.get("llm", {})
+    aex_data = data.get("aex", {})
+    skills_data = data.get("skills", [])
+
+    # Parse skills
+    skills = [
+        Skill(
+            id=s["id"],
+            name=s["name"],
+            description=s.get("description", ""),
+            tags=s.get("tags", []),
+            examples=s.get("examples", []),
+        )
+        for s in skills_data
+    ]
+
+    # Parse provider
+    provider = None
+    if "provider" in agent_data:
+        provider = Provider(
+            organization=agent_data["provider"].get("organization", ""),
+            url=agent_data["provider"].get("url"),
+        )
+
+    return AgentConfig(
+        name=agent_data.get("name", "Unknown Agent"),
+        description=agent_data.get("description", ""),
+        version=agent_data.get("version", "1.0.0"),
+        server=ServerConfig(
+            host=server_data.get("host", "0.0.0.0"),
+            port=server_data.get("port", 8100),
+        ),
+        llm=LLMConfig(
+            provider=llm_data.get("provider", "anthropic"),
+            model=llm_data.get("model", "claude-3-5-sonnet-20241022"),
+            temperature=llm_data.get("temperature", 0.7),
+            max_tokens=llm_data.get("max_tokens", 4096),
+        ),
+        aex=AEXConfig(
+            enabled=aex_data.get("enabled", True),
+            gateway_url=os.environ.get("AEX_GATEWAY_URL", aex_data.get("gateway_url", "http://localhost:8080")),
+            auto_register=aex_data.get("auto_register", True),
+            auto_bid=aex_data.get("auto_bid", True),
+            base_rate=aex_data.get("pricing", {}).get("base_rate", 25.0),
+            currency=aex_data.get("pricing", {}).get("currency", "USD"),
+        ),
+        skills=skills,
+        provider=provider,
+    )

--- a/demo/agents/common/requirements.txt
+++ b/demo/agents/common/requirements.txt
@@ -1,0 +1,10 @@
+# Common dependencies for AEX demo agents
+aiohttp>=3.9.0
+pyyaml>=6.0
+langgraph>=0.2.0
+langchain>=0.2.0
+langchain-core>=0.2.0
+
+# LLM providers (Claude and Gemini only)
+langchain-anthropic>=0.2.0
+langchain-google-genai>=2.0.0

--- a/demo/agents/legal-agent-a/agent.py
+++ b/demo/agents/legal-agent-a/agent.py
@@ -1,0 +1,151 @@
+"""Legal Agent A (Budget) - Fast, affordable contract review using Claude."""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import StateGraph, END
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.base_agent import BaseAgent, AgentState
+from common.config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+# Budget tier prompts - concise and fast
+CONTRACT_REVIEW_PROMPT = """You are a quick contract reviewer providing CONCISE analysis.
+Keep responses SHORT and focused on the most critical issues only.
+
+Provide:
+1. 3-5 key risks (one line each)
+2. Top 3 action items
+3. Overall risk rating (Low/Medium/High)
+
+Be direct. No lengthy explanations. Speed is priority."""
+
+LEGAL_RESEARCH_PROMPT = """You are a legal researcher providing QUICK summaries.
+Keep responses SHORT and actionable.
+
+Provide:
+1. Key regulations (bullet points)
+2. Main compliance requirements
+3. Immediate action items
+
+Be concise. No detailed explanations."""
+
+
+@dataclass
+class LegalAgentA(BaseAgent):
+    """Budget Legal Agent using Claude for fast, affordable analysis."""
+
+    llm: Optional[ChatAnthropic] = field(default=None, init=False)
+
+    def _setup_llm(self):
+        """Initialize Claude LLM."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set, using mock responses")
+            self.llm = None
+            return
+
+        self.llm = ChatAnthropic(
+            model=self.config.llm.model,
+            temperature=self.config.llm.temperature,
+            max_tokens=self.config.llm.max_tokens,
+            anthropic_api_key=api_key,
+        )
+        logger.info(f"Initialized Claude LLM (Budget): {self.config.llm.model}")
+
+    def _build_graph(self):
+        """Build the LangGraph workflow."""
+        self._graph = StateGraph(AgentState)
+
+    def _detect_skill(self, content: str) -> str:
+        """Detect which skill to use based on content."""
+        content_lower = content.lower()
+
+        contract_keywords = ["contract", "agreement", "terms", "clause", "review"]
+        if any(kw in content_lower for kw in contract_keywords):
+            return "contract_review"
+
+        return "legal_research"
+
+    async def process(self, state: AgentState) -> AgentState:
+        """Process the legal request through Gemini (fast mode)."""
+        messages = state["messages"]
+        if not messages:
+            state["result"] = "No message provided."
+            return state
+
+        user_content = messages[-1].get("content", "")
+        skill = self._detect_skill(user_content)
+
+        system_prompt = (
+            CONTRACT_REVIEW_PROMPT if skill == "contract_review"
+            else LEGAL_RESEARCH_PROMPT
+        )
+
+        if self.llm is None:
+            state["result"] = self._mock_response(skill, user_content)
+            state["artifacts"] = [{
+                "name": f"{skill}_quick_analysis.txt",
+                "parts": [{"type": "text", "text": state["result"]}],
+            }]
+            return state
+
+        try:
+            response = await self.llm.ainvoke([
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=user_content),
+            ])
+
+            result = response.content
+            state["result"] = result
+            state["artifacts"] = [{
+                "name": f"{skill}_quick_analysis.txt",
+                "parts": [{"type": "text", "text": result}],
+            }]
+
+        except Exception as e:
+            logger.exception(f"Error calling Claude: {e}")
+            state["result"] = f"Error processing request: {str(e)}"
+
+        return state
+
+    def _mock_response(self, skill: str, content: str) -> str:
+        """Generate mock response for testing (budget tier - concise)."""
+        if skill == "contract_review":
+            return """## Quick Contract Review
+
+**Risk Rating: MEDIUM**
+
+### Key Risks:
+- Liability cap too low for contract value
+- Auto-renewal clause favors other party
+- IP ownership ambiguous
+
+### Action Items:
+1. Negotiate higher liability cap
+2. Add 30-day termination notice
+3. Clarify IP assignment
+
+*Budget analysis - $10 | ~5 min*"""
+        else:
+            return """## Quick Legal Summary
+
+### Key Regulations:
+- GDPR applies (EU data)
+- Standard contract law
+- Industry compliance required
+
+### Actions Needed:
+1. Add privacy policy
+2. Update data handling
+3. Review annually
+
+*Budget analysis - $10 | ~5 min*"""

--- a/demo/agents/legal-agent-a/config.yaml
+++ b/demo/agents/legal-agent-a/config.yaml
@@ -1,0 +1,56 @@
+agent:
+  name: "Budget Legal AI"
+  description: "Fast, affordable contract review - basic analysis at low cost"
+  version: "1.0.0"
+  provider:
+    organization: "QuickLegal Inc"
+    url: "https://github.com/open-experiments/agent-exchange"
+
+server:
+  host: "0.0.0.0"
+  port: 8100
+
+llm:
+  provider: "anthropic"
+  model: "claude-sonnet-4-20250514"
+  temperature: 0.5
+  max_tokens: 2048
+
+# Agent characteristics for bidding
+characteristics:
+  tier: "budget"
+  response_style: "concise"
+  detail_level: "basic"
+  turnaround: "fast"
+
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Quick contract review highlighting major issues"
+    tags: ["legal", "contracts", "review"]
+    examples:
+      - "Review this contract quickly"
+      - "What are the main risks?"
+
+  - id: "legal_research"
+    name: "Legal Research"
+    description: "Basic legal research and summaries"
+    tags: ["legal", "research"]
+    examples:
+      - "Summarize key compliance requirements"
+
+aex:
+  enabled: true
+  gateway_url: "http://aex-gateway:8080"
+  auto_register: true
+  auto_bid: true
+  pricing:
+    base_rate: 5.00
+    per_page_rate: 2.00
+    max_pages_optimal: 5
+    currency: "USD"
+    description: "Best for quick reviews of short documents (1-5 pages)"
+  bidding:
+    confidence: 0.75
+    estimated_time_minutes: 3
+    max_document_pages: 10

--- a/demo/agents/legal-agent-a/main.py
+++ b/demo/agents/legal-agent-a/main.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Legal Agent A - Main entry point."""
+
+import asyncio
+import logging
+import os
+import sys
+
+# Add parent directory to path for common imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.a2a_server import A2AServer
+from common.config import load_config
+from agent import LegalAgentA
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Start the Legal Agent A server."""
+    # Load configuration
+    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config = load_config(config_path)
+
+    logger.info(f"Starting {config.name}")
+    logger.info(f"Skills: {[s.id for s in config.skills]}")
+
+    # Create agent
+    agent = LegalAgentA(config=config)
+
+    # Generate agent card
+    # Use AGENT_HOSTNAME env var for Docker, fallback to localhost
+    hostname = os.environ.get("AGENT_HOSTNAME", "localhost")
+    base_url = f"http://{hostname}:{config.server.port}"
+
+    agent_card = config.get_agent_card(base_url)
+
+    # Create A2A server
+    server = A2AServer(
+        agent_card=agent_card,
+        handler=agent,
+        require_auth=False,  # For demo, don't require auth
+    )
+
+    # Register with AEX if enabled
+    if config.aex.enabled and config.aex.auto_register:
+        try:
+            await agent.register_with_aex(base_url)
+        except Exception as e:
+            logger.warning(f"Could not register with AEX: {e}")
+
+    # Run server
+    logger.info(f"Agent Card: {base_url}/.well-known/agent-card.json")
+    logger.info(f"A2A Endpoint: {base_url}/a2a")
+    await server.run_async(host=config.server.host, port=config.server.port)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demo/agents/legal-agent-a/requirements.txt
+++ b/demo/agents/legal-agent-a/requirements.txt
@@ -1,0 +1,5 @@
+# Legal Agent A (Budget) dependencies
+-r ../common/requirements.txt
+
+# Uses Claude via langchain-anthropic (included in common)
+anthropic>=0.34.0

--- a/demo/agents/legal-agent-b/agent.py
+++ b/demo/agents/legal-agent-b/agent.py
@@ -1,0 +1,248 @@
+"""Legal Agent B (Standard) - Balanced contract review using Claude."""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import StateGraph, END
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.base_agent import BaseAgent, AgentState
+from common.config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+# Standard tier prompts - balanced detail
+CONTRACT_REVIEW_PROMPT = """You are an experienced contract attorney providing thorough analysis.
+
+Provide a COMPREHENSIVE review including:
+
+1. **Executive Summary** (2-3 sentences)
+2. **Key Terms Analysis**
+   - Payment terms and conditions
+   - Duration and renewal provisions
+   - Termination rights
+3. **Risk Assessment**
+   - Identify all material risks
+   - Rate each risk (Low/Medium/High)
+   - Explain potential impact
+4. **Party Obligations**
+   - Your client's obligations
+   - Counterparty obligations
+5. **Recommendations**
+   - Specific clauses to negotiate
+   - Suggested modifications
+   - Deal breakers to watch for
+
+Be thorough but organized. Use tables where helpful."""
+
+COMPLIANCE_CHECK_PROMPT = """You are a compliance specialist providing detailed regulatory analysis.
+
+Provide a COMPREHENSIVE compliance assessment:
+
+1. **Regulatory Framework**
+   - Applicable laws and regulations
+   - Jurisdictional considerations
+2. **Compliance Checklist**
+   - Map requirements to document sections
+   - Identify gaps and violations
+3. **Risk Matrix**
+   - Categorize by severity
+   - Estimate remediation effort
+4. **Action Plan**
+   - Prioritized remediation steps
+   - Timeline recommendations
+
+Be specific about which regulations apply and why."""
+
+LEGAL_RESEARCH_PROMPT = """You are a legal researcher providing in-depth analysis.
+
+Provide THOROUGH research including:
+
+1. **Legal Framework** - Applicable laws and statutes
+2. **Key Requirements** - Detailed compliance obligations
+3. **Case Context** - Relevant precedents if applicable
+4. **Practical Implications** - How this affects the client
+5. **Recommendations** - Specific next steps
+
+Include citations where possible."""
+
+
+@dataclass
+class LegalAgentB(BaseAgent):
+    """Standard Legal Agent using Claude for balanced, thorough analysis."""
+
+    llm: Optional[ChatAnthropic] = field(default=None, init=False)
+
+    def _setup_llm(self):
+        """Initialize Claude LLM."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set, using mock responses")
+            self.llm = None
+            return
+
+        self.llm = ChatAnthropic(
+            model=self.config.llm.model,
+            temperature=self.config.llm.temperature,
+            max_tokens=self.config.llm.max_tokens,
+            api_key=api_key,
+        )
+        logger.info(f"Initialized Claude LLM (Standard): {self.config.llm.model}")
+
+    def _build_graph(self):
+        """Build the LangGraph workflow."""
+        self._graph = StateGraph(AgentState)
+
+    def _detect_skill(self, content: str) -> str:
+        """Detect which skill to use based on content."""
+        content_lower = content.lower()
+
+        compliance_keywords = [
+            "compliance", "gdpr", "ccpa", "hipaa", "regulation",
+            "privacy", "data protection", "audit"
+        ]
+        if any(kw in content_lower for kw in compliance_keywords):
+            return "compliance_check"
+
+        research_keywords = ["research", "law", "statute", "requirement"]
+        if any(kw in content_lower for kw in research_keywords):
+            return "legal_research"
+
+        return "contract_review"
+
+    async def process(self, state: AgentState) -> AgentState:
+        """Process the legal request through Claude (standard mode)."""
+        messages = state["messages"]
+        if not messages:
+            state["result"] = "No message provided."
+            return state
+
+        user_content = messages[-1].get("content", "")
+        skill = self._detect_skill(user_content)
+
+        prompts = {
+            "contract_review": CONTRACT_REVIEW_PROMPT,
+            "compliance_check": COMPLIANCE_CHECK_PROMPT,
+            "legal_research": LEGAL_RESEARCH_PROMPT,
+        }
+        system_prompt = prompts.get(skill, CONTRACT_REVIEW_PROMPT)
+
+        if self.llm is None:
+            state["result"] = self._mock_response(skill, user_content)
+            state["artifacts"] = [{
+                "name": f"{skill}_standard_report.txt",
+                "parts": [{"type": "text", "text": state["result"]}],
+            }]
+            return state
+
+        try:
+            response = await self.llm.ainvoke([
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=user_content),
+            ])
+
+            result = response.content
+            state["result"] = result
+            state["artifacts"] = [{
+                "name": f"{skill}_standard_report.txt",
+                "parts": [{"type": "text", "text": result}],
+            }]
+
+        except Exception as e:
+            logger.exception(f"Error calling Claude: {e}")
+            state["result"] = f"Error processing request: {str(e)}"
+
+        return state
+
+    def _mock_response(self, skill: str, content: str) -> str:
+        """Generate mock response for testing (standard tier - balanced)."""
+        if skill == "contract_review":
+            return """## Contract Review Report
+
+### Executive Summary
+This service agreement establishes a 12-month engagement with standard commercial terms. Several provisions require attention before signing, particularly around liability and IP ownership.
+
+### Key Terms Analysis
+
+| Term | Current State | Assessment |
+|------|--------------|------------|
+| **Payment** | Net-30, milestone-based | Standard, acceptable |
+| **Duration** | 12 months, auto-renewal | Add termination notice period |
+| **Liability** | Capped at contract value | Consider increasing cap |
+| **IP Rights** | Shared ownership | Needs clarification |
+| **Confidentiality** | Mutual, 3-year term | Standard |
+
+### Risk Assessment
+
+| Risk | Level | Impact | Mitigation |
+|------|-------|--------|------------|
+| Liability exposure | **Medium** | Financial | Negotiate higher cap |
+| IP ownership dispute | **Medium** | Operational | Define ownership clearly |
+| Auto-renewal lock-in | **Low** | Flexibility | Add 60-day notice |
+| Payment delays | **Low** | Cash flow | Standard terms |
+
+### Party Obligations
+
+**Your Obligations:**
+- Deliver services per SOW
+- Maintain confidentiality
+- Provide qualified personnel
+
+**Counterparty Obligations:**
+- Timely payment
+- Reasonable cooperation
+- Access to necessary resources
+
+### Recommendations
+
+1. **Negotiate**: Increase liability cap to 2x contract value
+2. **Clarify**: Add specific IP assignment clause
+3. **Add**: 60-day termination notice requirement
+4. **Review**: Insurance requirements
+
+*Standard analysis - $25 | ~15 min*"""
+        else:
+            return """## Compliance Assessment Report
+
+### Regulatory Framework
+
+**Applicable Regulations:**
+- GDPR (EU General Data Protection Regulation)
+- Local data protection laws
+- Industry-specific requirements
+
+### Compliance Checklist
+
+| Requirement | Status | Evidence | Gap |
+|------------|--------|----------|-----|
+| Lawful basis for processing | Partial | Section 3.2 | Missing explicit consent |
+| Data subject rights | Compliant | Section 5 | None |
+| Data retention policy | Non-compliant | Missing | No policy documented |
+| Security measures | Partial | Section 7 | Technical measures unclear |
+| Breach notification | Compliant | Section 8 | None |
+
+### Risk Matrix
+
+| Issue | Severity | Likelihood | Remediation Effort |
+|-------|----------|------------|-------------------|
+| Missing retention policy | **High** | Likely | Medium (2-3 days) |
+| Unclear consent | **Medium** | Possible | Low (1 day) |
+| Security documentation | **Low** | Unlikely | Low (1 day) |
+
+### Action Plan
+
+**Immediate (Week 1):**
+1. Draft data retention policy
+2. Update consent mechanisms
+
+**Short-term (Month 1):**
+3. Document security measures
+4. Conduct gap assessment
+
+*Standard analysis - $25 | ~15 min*"""

--- a/demo/agents/legal-agent-b/config.yaml
+++ b/demo/agents/legal-agent-b/config.yaml
@@ -1,0 +1,64 @@
+agent:
+  name: "Standard Legal AI"
+  description: "Balanced contract review - thorough analysis at competitive rates"
+  version: "1.0.0"
+  provider:
+    organization: "LegalTech Solutions"
+    url: "https://github.com/open-experiments/agent-exchange"
+
+server:
+  host: "0.0.0.0"
+  port: 8101
+
+llm:
+  provider: "anthropic"
+  model: "claude-sonnet-4-20250514"
+  temperature: 0.3
+  max_tokens: 4096
+
+# Agent characteristics for bidding
+characteristics:
+  tier: "standard"
+  response_style: "detailed"
+  detail_level: "comprehensive"
+  turnaround: "moderate"
+
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Comprehensive contract analysis with risk assessment and recommendations"
+    tags: ["legal", "contracts", "review"]
+    examples:
+      - "Review this partnership agreement thoroughly"
+      - "Identify all risks and obligations"
+
+  - id: "compliance_check"
+    name: "Compliance Check"
+    description: "Detailed regulatory compliance analysis"
+    tags: ["legal", "compliance"]
+    examples:
+      - "Check GDPR compliance of this privacy policy"
+      - "Verify contract meets industry standards"
+
+  - id: "legal_research"
+    name: "Legal Research"
+    description: "In-depth legal research with citations"
+    tags: ["legal", "research"]
+    examples:
+      - "Research employment law requirements"
+
+aex:
+  enabled: true
+  gateway_url: "http://aex-gateway:8080"
+  auto_register: true
+  auto_bid: true
+  pricing:
+    base_rate: 15.00
+    per_page_rate: 0.50
+    max_pages_optimal: 30
+    currency: "USD"
+    description: "Balanced pricing for medium-length documents (5-30 pages)"
+  bidding:
+    confidence: 0.88
+    estimated_time_minutes: 15
+    max_document_pages: 50

--- a/demo/agents/legal-agent-b/main.py
+++ b/demo/agents/legal-agent-b/main.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Legal Agent B - Main entry point."""
+
+import asyncio
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.a2a_server import A2AServer
+from common.config import load_config
+from agent import LegalAgentB
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Start the Legal Agent B server."""
+    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config = load_config(config_path)
+
+    logger.info(f"Starting {config.name}")
+    logger.info(f"Skills: {[s.id for s in config.skills]}")
+
+    agent = LegalAgentB(config=config)
+
+    # Use AGENT_HOSTNAME env var for Docker, fallback to localhost
+    hostname = os.environ.get("AGENT_HOSTNAME", "localhost")
+    base_url = f"http://{hostname}:{config.server.port}"
+
+    agent_card = config.get_agent_card(base_url)
+
+    server = A2AServer(
+        agent_card=agent_card,
+        handler=agent,
+        require_auth=False,
+    )
+
+    if config.aex.enabled and config.aex.auto_register:
+        try:
+            await agent.register_with_aex(base_url)
+        except Exception as e:
+            logger.warning(f"Could not register with AEX: {e}")
+
+    logger.info(f"Agent Card: {base_url}/.well-known/agent-card.json")
+    logger.info(f"A2A Endpoint: {base_url}/a2a")
+    await server.run_async(host=config.server.host, port=config.server.port)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demo/agents/legal-agent-b/requirements.txt
+++ b/demo/agents/legal-agent-b/requirements.txt
@@ -1,0 +1,5 @@
+# Legal Agent B (Standard) dependencies
+-r ../common/requirements.txt
+
+# Uses Claude via langchain-anthropic (included in common)
+anthropic>=0.34.0

--- a/demo/agents/legal-agent-c/agent.py
+++ b/demo/agents/legal-agent-c/agent.py
@@ -1,0 +1,485 @@
+"""Legal Agent C (Premium) - Expert-level contract review using Claude."""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import StateGraph, END
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.base_agent import BaseAgent, AgentState
+from common.config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+# Premium tier prompts - exhaustive expert analysis
+CONTRACT_REVIEW_PROMPT = """You are a senior partner at a top law firm providing EXHAUSTIVE contract analysis.
+
+Deliver EXPERT-LEVEL analysis including:
+
+1. **Executive Summary** - Strategic overview for C-suite
+2. **Deal Structure Analysis**
+   - Commercial terms breakdown
+   - Value assessment
+   - Market comparison
+3. **Comprehensive Risk Matrix**
+   - ALL identified risks categorized by:
+     * Legal risk
+     * Financial risk
+     * Operational risk
+     * Reputational risk
+   - Probability and impact scoring
+   - Cumulative risk exposure
+4. **Clause-by-Clause Analysis**
+   - Every material clause reviewed
+   - Standard vs. non-standard terms
+   - Hidden traps and gotchas
+5. **Negotiation Strategy**
+   - Leverage points
+   - Walk-away triggers
+   - Alternative clause language
+   - Fallback positions
+6. **Regulatory Considerations**
+   - Applicable laws
+   - Jurisdictional issues
+   - Future regulatory risks
+7. **Precedent Analysis**
+   - Similar deals reviewed
+   - Industry standards
+8. **Strategic Recommendations**
+   - Prioritized negotiation points
+   - Deal breakers
+   - Accept/reject recommendation
+
+This is board-level analysis. Be exhaustive. Miss nothing."""
+
+COMPLIANCE_CHECK_PROMPT = """You are a chief compliance officer providing EXHAUSTIVE regulatory analysis.
+
+Deliver EXPERT-LEVEL compliance assessment:
+
+1. **Executive Summary** - Board-level compliance status
+2. **Multi-Jurisdictional Analysis**
+   - All applicable regulations by jurisdiction
+   - Conflicts of law analysis
+   - Extraterritorial implications
+3. **Comprehensive Compliance Matrix**
+   - Every requirement mapped
+   - Evidence assessment
+   - Gap severity scoring
+4. **Risk Quantification**
+   - Penalty exposure calculations
+   - Enforcement likelihood
+   - Reputational impact assessment
+5. **Remediation Roadmap**
+   - Detailed action items
+   - Resource requirements
+   - Timeline with milestones
+   - Budget estimates
+6. **Governance Recommendations**
+   - Policy updates needed
+   - Training requirements
+   - Monitoring systems
+7. **Audit Trail Documentation**
+   - Evidence preservation
+   - Documentation requirements
+
+This is for regulatory filing purposes. Be exhaustive."""
+
+LEGAL_RESEARCH_PROMPT = """You are a senior legal researcher providing EXHAUSTIVE analysis.
+
+Deliver EXPERT-LEVEL research:
+
+1. **Legal Framework** - Complete statutory landscape
+2. **Case Law Analysis** - Relevant precedents with citations
+3. **Regulatory Guidance** - Agency interpretations
+4. **Comparative Analysis** - Multi-jurisdictional view
+5. **Risk Assessment** - Litigation exposure
+6. **Strategic Recommendations** - Actionable guidance
+
+Include full citations. This is litigation-grade research."""
+
+NEGOTIATION_PROMPT = """You are a senior negotiation strategist.
+
+Provide COMPREHENSIVE negotiation support:
+
+1. **Leverage Analysis** - Your strengths and weaknesses
+2. **Counterparty Assessment** - Their likely positions
+3. **Alternative Clauses** - Draft language options
+4. **BATNA Analysis** - Best alternatives
+5. **Concession Strategy** - What to give, what to hold
+6. **Deal Structure Options** - Creative solutions
+
+Be strategic and thorough."""
+
+
+@dataclass
+class LegalAgentC(BaseAgent):
+    """Premium Legal Agent using Claude for exhaustive, expert-level analysis."""
+
+    llm: Optional[ChatAnthropic] = field(default=None, init=False)
+
+    def _setup_llm(self):
+        """Initialize Claude LLM."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set, using mock responses")
+            self.llm = None
+            return
+
+        self.llm = ChatAnthropic(
+            model=self.config.llm.model,
+            temperature=self.config.llm.temperature,
+            max_tokens=self.config.llm.max_tokens,
+            api_key=api_key,
+        )
+        logger.info(f"Initialized Claude LLM (Premium): {self.config.llm.model}")
+
+    def _build_graph(self):
+        """Build the LangGraph workflow."""
+        self._graph = StateGraph(AgentState)
+
+    def _detect_skill(self, content: str) -> str:
+        """Detect which skill to use based on content."""
+        content_lower = content.lower()
+
+        compliance_keywords = [
+            "compliance", "gdpr", "ccpa", "hipaa", "regulation",
+            "privacy", "data protection", "audit"
+        ]
+        if any(kw in content_lower for kw in compliance_keywords):
+            return "compliance_check"
+
+        negotiation_keywords = ["negotiate", "negotiation", "leverage", "strategy"]
+        if any(kw in content_lower for kw in negotiation_keywords):
+            return "negotiation_support"
+
+        research_keywords = ["research", "law", "statute", "case", "precedent"]
+        if any(kw in content_lower for kw in research_keywords):
+            return "legal_research"
+
+        return "contract_review"
+
+    async def process(self, state: AgentState) -> AgentState:
+        """Process the legal request through Claude (premium mode)."""
+        messages = state["messages"]
+        if not messages:
+            state["result"] = "No message provided."
+            return state
+
+        user_content = messages[-1].get("content", "")
+        skill = self._detect_skill(user_content)
+
+        prompts = {
+            "contract_review": CONTRACT_REVIEW_PROMPT,
+            "compliance_check": COMPLIANCE_CHECK_PROMPT,
+            "legal_research": LEGAL_RESEARCH_PROMPT,
+            "negotiation_support": NEGOTIATION_PROMPT,
+        }
+        system_prompt = prompts.get(skill, CONTRACT_REVIEW_PROMPT)
+
+        if self.llm is None:
+            state["result"] = self._mock_response(skill, user_content)
+            state["artifacts"] = [{
+                "name": f"{skill}_premium_report.txt",
+                "parts": [{"type": "text", "text": state["result"]}],
+            }]
+            return state
+
+        try:
+            response = await self.llm.ainvoke([
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=user_content),
+            ])
+
+            result = response.content
+            state["result"] = result
+            state["artifacts"] = [{
+                "name": f"{skill}_premium_report.txt",
+                "parts": [{"type": "text", "text": result}],
+            }]
+
+        except Exception as e:
+            logger.exception(f"Error calling Claude: {e}")
+            state["result"] = f"Error processing request: {str(e)}"
+
+        return state
+
+    def _mock_response(self, skill: str, content: str) -> str:
+        """Generate mock response for testing (premium tier - exhaustive)."""
+        if skill == "contract_review":
+            return """## Premium Contract Analysis Report
+### Prepared by Elite Legal Partners
+
+---
+
+## 1. Executive Summary
+
+This Master Service Agreement presents a **moderate-to-high risk profile** requiring significant negotiation before execution. Key concerns include liability limitations, IP ownership ambiguity, and one-sided termination provisions. **Recommendation: Do not sign without amendments.**
+
+---
+
+## 2. Deal Structure Analysis
+
+### 2.1 Commercial Terms
+
+| Element | Terms | Market Comparison | Assessment |
+|---------|-------|-------------------|------------|
+| Contract Value | $500,000/year | Market rate | Fair |
+| Payment Terms | Net-30 | Industry: Net-45 | Favorable |
+| Term | 36 months | Typical: 12-24 | Long commitment |
+| Renewal | Auto-renewal | Concerning | Negotiate |
+
+### 2.2 Value Assessment
+- **Total Contract Value**: $1.5M over term
+- **Maximum Liability Exposure**: $500K (capped)
+- **Hidden Costs Identified**: ~$75K in compliance requirements
+
+---
+
+## 3. Comprehensive Risk Matrix
+
+### 3.1 Legal Risks
+
+| Risk | Probability | Impact | Score | Mitigation |
+|------|------------|--------|-------|------------|
+| IP ownership dispute | High | Critical | **9/10** | Rewrite Section 8 |
+| Indemnification trigger | Medium | High | **7/10** | Cap at contract value |
+| Regulatory non-compliance | Medium | Medium | **5/10** | Add compliance rep |
+| Jurisdiction risk | Low | High | **4/10** | Arbitration clause |
+
+### 3.2 Financial Risks
+
+| Risk | Exposure | Likelihood | Annual Impact |
+|------|----------|------------|---------------|
+| Early termination penalty | $250K | 20% | $50K |
+| Uncapped liability event | Unlimited | 5% | Unknown |
+| Payment dispute | $150K | 15% | $22.5K |
+
+### 3.3 Cumulative Risk Exposure
+**Estimated Maximum Exposure: $1.2M**
+**Expected Annual Risk Cost: $95K**
+
+---
+
+## 4. Clause-by-Clause Analysis
+
+### Section 1: Definitions
+- **Status**: Standard
+- **Issues**: None material
+- **Action**: Accept as-is
+
+### Section 3: Scope of Services
+- **Status**: Non-standard
+- **Issues**: Scope creep language in 3.4(b)
+- **Action**: Add change order requirement
+
+### Section 5: Payment Terms
+- **Status**: Favorable
+- **Issues**: Late payment interest excessive (18%)
+- **Action**: Negotiate to 12%
+
+### Section 7: Limitation of Liability
+- **Status**: CRITICAL CONCERN
+- **Issues**:
+  - Cap too low ($100K vs. $500K contract)
+  - Carve-outs favor counterparty
+  - No mutual limitation
+- **Action**: MUST renegotiate before signing
+
+### Section 8: Intellectual Property
+- **Status**: CRITICAL CONCERN
+- **Issues**:
+  - Work product ownership unclear
+  - Background IP not protected
+  - License-back provisions missing
+- **Action**: Complete rewrite required
+
+### Section 12: Termination
+- **Status**: One-sided
+- **Issues**:
+  - Counterparty: 30-day convenience termination
+  - Your termination: Only for material breach
+- **Action**: Add mutual convenience termination
+
+---
+
+## 5. Negotiation Strategy
+
+### 5.1 Leverage Points
+1. Market alternatives available
+2. Long-term commitment being offered
+3. Counterparty needs this deal for Q4 numbers
+
+### 5.2 Priority Negotiation Items
+
+| Priority | Item | Current | Target | Fallback |
+|----------|------|---------|--------|----------|
+| 1 | Liability cap | $100K | $1M | $500K |
+| 2 | IP ownership | Unclear | Full ownership | License-back |
+| 3 | Termination | One-sided | Mutual 90-day | Mutual 60-day |
+| 4 | Auto-renewal | Silent | 90-day notice | 60-day notice |
+
+### 5.3 Walk-Away Triggers
+- Liability cap below $250K
+- No IP ownership clarity
+- Unlimited indemnification
+
+### 5.4 Alternative Clause Language
+
+**Proposed Section 7.1 (Liability):**
+> "Each party's aggregate liability under this Agreement shall not exceed two times (2x) the total fees paid or payable during the twelve (12) month period immediately preceding the claim, provided that this limitation shall not apply to: (a) breaches of confidentiality, (b) willful misconduct, or (c) indemnification obligations."
+
+---
+
+## 6. Regulatory Considerations
+
+- **GDPR**: Data processing addendum required
+- **CCPA**: Privacy notice updates needed
+- **SOC 2**: Audit rights should be added
+- **Industry Regs**: Sector-specific compliance TBD
+
+---
+
+## 7. Strategic Recommendations
+
+### Immediate Actions
+1. **DO NOT SIGN** current version
+2. Send redline with priority amendments
+3. Schedule negotiation call for this week
+
+### Deal Recommendation
+**Proceed with caution** - Deal is commercially attractive but legal terms require significant modification. Estimated negotiation time: 2-3 weeks.
+
+---
+
+*Premium analysis - $50 | ~30 min*
+*Prepared by Elite Legal Partners - Confidential*"""
+        else:
+            return """## Premium Compliance Assessment Report
+### Prepared by Elite Legal Partners
+
+---
+
+## 1. Executive Summary
+
+**Overall Compliance Status: HIGH RISK**
+
+This assessment identifies **12 compliance gaps** across **4 regulatory frameworks**, with an estimated penalty exposure of **$2.4M**. Immediate remediation required before regulatory audit.
+
+---
+
+## 2. Multi-Jurisdictional Analysis
+
+### 2.1 Applicable Regulations
+
+| Regulation | Jurisdiction | Applicability | Risk Level |
+|------------|-------------|---------------|------------|
+| GDPR | EU/EEA | **Full** | Critical |
+| CCPA/CPRA | California | **Full** | High |
+| LGPD | Brazil | Partial | Medium |
+| PIPEDA | Canada | Partial | Low |
+
+### 2.2 Extraterritorial Implications
+- EU data subjects trigger GDPR regardless of processing location
+- California revenue threshold exceeded - CPRA applies
+- Brazilian subsidiaries trigger LGPD
+
+---
+
+## 3. Comprehensive Compliance Matrix
+
+### 3.1 GDPR Compliance
+
+| Article | Requirement | Status | Evidence | Gap Severity |
+|---------|-------------|--------|----------|--------------|
+| Art. 6 | Lawful basis | Partial | Privacy Policy 3.2 | **High** |
+| Art. 7 | Consent | Non-compliant | Missing | **Critical** |
+| Art. 13-14 | Transparency | Partial | Incomplete | **Medium** |
+| Art. 15-22 | Data subject rights | Compliant | Portal exists | None |
+| Art. 25 | Privacy by design | Non-compliant | No documentation | **High** |
+| Art. 30 | Processing records | Non-compliant | Missing | **High** |
+| Art. 32 | Security measures | Partial | SOC 2 pending | **Medium** |
+| Art. 33-34 | Breach notification | Compliant | Policy exists | None |
+
+### 3.2 Overall Gap Score: 62/100 (High Risk)
+
+---
+
+## 4. Risk Quantification
+
+### 4.1 Penalty Exposure
+
+| Regulation | Max Penalty | Likely Penalty | Probability | Expected Cost |
+|------------|-------------|----------------|-------------|---------------|
+| GDPR | 4% revenue (~$8M) | $1.5M | 30% | $450K |
+| CCPA | $7,500/violation | $500K | 40% | $200K |
+| Class action | N/A | $2M | 15% | $300K |
+| **Total** | | | | **$950K** |
+
+### 4.2 Non-Monetary Risks
+- Regulatory investigation: 6-12 months disruption
+- Reputational damage: Customer churn estimated 5-8%
+- M&A impact: Due diligence red flag
+
+---
+
+## 5. Remediation Roadmap
+
+### Phase 1: Critical (0-30 days) - Budget: $75K
+
+| # | Action | Owner | Deadline | Cost |
+|---|--------|-------|----------|------|
+| 1 | Implement consent management | Privacy | Day 14 | $25K |
+| 2 | Create processing records | Legal | Day 21 | $15K |
+| 3 | Update privacy notices | Marketing | Day 30 | $10K |
+| 4 | Privacy impact assessment | Privacy | Day 30 | $25K |
+
+### Phase 2: High Priority (30-90 days) - Budget: $150K
+
+| # | Action | Owner | Deadline | Cost |
+|---|--------|-------|----------|------|
+| 5 | Privacy by design framework | Engineering | Day 60 | $50K |
+| 6 | Data mapping exercise | IT | Day 75 | $40K |
+| 7 | Vendor assessment program | Procurement | Day 90 | $30K |
+| 8 | Training program rollout | HR | Day 90 | $30K |
+
+### Phase 3: Maintenance (90+ days) - Budget: $50K/year
+
+| # | Action | Frequency | Cost |
+|---|--------|-----------|------|
+| 9 | Annual compliance audit | Yearly | $25K |
+| 10 | Continuous monitoring | Ongoing | $25K |
+
+---
+
+## 6. Governance Recommendations
+
+### 6.1 Policy Updates Required
+1. Data Retention Policy - NEW
+2. Privacy Policy - MAJOR UPDATE
+3. Incident Response Plan - MINOR UPDATE
+4. Vendor Management Policy - NEW
+
+### 6.2 Training Requirements
+- All employees: Privacy fundamentals (2 hours)
+- Engineering: Privacy by design (4 hours)
+- Customer support: DSAR handling (3 hours)
+- Leadership: Regulatory landscape (1 hour)
+
+---
+
+## 7. Board-Level Summary
+
+**Compliance investment required: $275K (Year 1)**
+**Risk reduction: 85% penalty exposure eliminated**
+**ROI: 3.5x based on expected cost avoidance**
+
+---
+
+*Premium analysis - $50 | ~30 min*
+*Prepared by Elite Legal Partners - Confidential*"""

--- a/demo/agents/legal-agent-c/config.yaml
+++ b/demo/agents/legal-agent-c/config.yaml
@@ -1,0 +1,73 @@
+agent:
+  name: "Premium Legal AI"
+  description: "Expert-level contract review - exhaustive analysis with strategic recommendations"
+  version: "1.0.0"
+  provider:
+    organization: "Elite Legal Partners"
+    url: "https://github.com/open-experiments/agent-exchange"
+
+server:
+  host: "0.0.0.0"
+  port: 8102
+
+llm:
+  provider: "anthropic"
+  model: "claude-sonnet-4-20250514"
+  temperature: 0.2
+  max_tokens: 8192
+
+# Agent characteristics for bidding
+characteristics:
+  tier: "premium"
+  response_style: "exhaustive"
+  detail_level: "expert"
+  turnaround: "thorough"
+
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Expert-level contract analysis with strategic recommendations, risk matrix, and negotiation points"
+    tags: ["legal", "contracts", "review"]
+    examples:
+      - "Perform exhaustive contract review with strategic advice"
+      - "Provide detailed risk matrix and mitigation strategies"
+
+  - id: "compliance_check"
+    name: "Compliance Check"
+    description: "Multi-jurisdictional compliance analysis with remediation roadmap"
+    tags: ["legal", "compliance"]
+    examples:
+      - "Full GDPR/CCPA compliance audit"
+      - "Cross-border regulatory analysis"
+
+  - id: "legal_research"
+    name: "Legal Research"
+    description: "Comprehensive legal research with case law citations and precedent analysis"
+    tags: ["legal", "research"]
+    examples:
+      - "Research with full case citations"
+      - "Comparative jurisdiction analysis"
+
+  - id: "negotiation_support"
+    name: "Negotiation Support"
+    description: "Strategic negotiation recommendations and alternative clause drafting"
+    tags: ["legal", "negotiation"]
+    examples:
+      - "Suggest alternative clauses"
+      - "Provide negotiation leverage points"
+
+aex:
+  enabled: true
+  gateway_url: "http://aex-gateway:8080"
+  auto_register: true
+  auto_bid: true
+  pricing:
+    base_rate: 30.00
+    per_page_rate: 0.20
+    max_pages_optimal: 100
+    currency: "USD"
+    description: "Best value for large, complex documents (30+ pages)"
+  bidding:
+    confidence: 0.95
+    estimated_time_minutes: 30
+    max_document_pages: 200

--- a/demo/agents/legal-agent-c/main.py
+++ b/demo/agents/legal-agent-c/main.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Legal Agent C (Premium) - Main entry point."""
+
+import asyncio
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.a2a_server import A2AServer
+from common.config import load_config
+from agent import LegalAgentC
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Start the Legal Agent C (Premium) server."""
+    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config = load_config(config_path)
+
+    logger.info(f"Starting {config.name} (Premium Tier)")
+    logger.info(f"Skills: {[s.id for s in config.skills]}")
+    logger.info(f"Pricing: ${config.aex.base_rate}/request")
+
+    agent = LegalAgentC(config=config)
+
+    # Use AGENT_HOSTNAME env var for Docker, fallback to localhost
+    hostname = os.environ.get("AGENT_HOSTNAME", "localhost")
+    base_url = f"http://{hostname}:{config.server.port}"
+
+    agent_card = config.get_agent_card(base_url)
+
+    server = A2AServer(
+        agent_card=agent_card,
+        handler=agent,
+        require_auth=False,
+    )
+
+    if config.aex.enabled and config.aex.auto_register:
+        try:
+            await agent.register_with_aex(base_url)
+        except Exception as e:
+            logger.warning(f"Could not register with AEX: {e}")
+
+    logger.info(f"Agent Card: {base_url}/.well-known/agent-card.json")
+    logger.info(f"A2A Endpoint: {base_url}/a2a")
+    await server.run_async(host=config.server.host, port=config.server.port)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demo/agents/legal-agent-c/requirements.txt
+++ b/demo/agents/legal-agent-c/requirements.txt
@@ -1,0 +1,5 @@
+# Legal Agent C (Premium) dependencies
+-r ../common/requirements.txt
+
+# Uses Claude via langchain-anthropic (included in common)
+anthropic>=0.34.0

--- a/demo/agents/orchestrator/agent.py
+++ b/demo/agents/orchestrator/agent.py
@@ -1,0 +1,447 @@
+"""Orchestrator Agent - Task decomposition and multi-agent coordination."""
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+import aiohttp
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import StateGraph, END
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.base_agent import BaseAgent, AgentState
+from common.config import AgentConfig
+from common.aex_client import AEXClient
+
+logger = logging.getLogger(__name__)
+
+ORCHESTRATOR_PROMPT = """You are an intelligent orchestrator that decomposes complex user requests into subtasks.
+
+Given a user request, identify the required subtasks and the skills needed for each.
+Output a JSON object with the following structure:
+
+{
+    "understanding": "Brief summary of what the user wants",
+    "subtasks": [
+        {
+            "id": "task_1",
+            "description": "What needs to be done",
+            "skill_tags": ["skill_tag_1", "skill_tag_2"],
+            "input": "Specific input for this subtask",
+            "depends_on": []
+        }
+    ],
+    "execution_order": "parallel" or "sequential"
+}
+
+Available skill tags:
+- contract_review: Review and analyze contracts (basic review)
+- legal_research: Research legal topics and regulations
+- compliance_check: Check regulatory compliance
+- negotiation_support: Strategic negotiation advice and alternative clause suggestions
+- risk_analysis: Detailed risk assessment and mitigation strategies (premium)
+- flight_booking: Search and book flights
+- hotel_booking: Search and book hotels
+- itinerary_planning: Create travel itineraries
+
+For complex legal requests, consider decomposing into:
+1. Basic contract_review for quick overview
+2. compliance_check for regulatory issues
+3. negotiation_support for strategic advice on problematic clauses
+4. risk_analysis for detailed risk assessment
+
+Be specific about what each subtask should accomplish.
+Return ONLY the JSON object, no additional text."""
+
+
+@dataclass
+class SubTask:
+    """A subtask identified by the orchestrator."""
+    id: str
+    description: str
+    skill_tags: list[str]
+    input: str
+    depends_on: list[str]
+    result: Optional[str] = None
+    status: str = "pending"
+    provider_id: Optional[str] = None
+    agent_url: Optional[str] = None
+
+
+@dataclass
+class OrchestratorAgent(BaseAgent):
+    """Orchestrator that coordinates multiple agents via AEX + A2A."""
+
+    llm: Optional[ChatAnthropic] = field(default=None, init=False)
+    http_session: Optional[aiohttp.ClientSession] = field(default=None, init=False)
+
+    def _setup_llm(self):
+        """Initialize Claude LLM for task decomposition."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set, using mock decomposition")
+            self.llm = None
+            return
+
+        self.llm = ChatAnthropic(
+            model=self.config.llm.model,
+            temperature=self.config.llm.temperature,
+            max_tokens=self.config.llm.max_tokens,
+            api_key=api_key,
+        )
+        logger.info(f"Initialized Claude LLM: {self.config.llm.model}")
+
+    def _build_graph(self):
+        """Build the orchestration workflow."""
+        self._graph = StateGraph(AgentState)
+
+    async def process(self, state: AgentState) -> AgentState:
+        """Process request through orchestration pipeline."""
+        messages = state["messages"]
+        if not messages:
+            state["result"] = "No message provided."
+            return state
+
+        user_content = messages[-1].get("content", "")
+
+        # Step 1: Decompose task
+        subtasks = await self._decompose_task(user_content)
+        if not subtasks:
+            state["result"] = "Could not decompose the request into subtasks."
+            return state
+
+        logger.info(f"Decomposed into {len(subtasks)} subtasks")
+
+        # Step 2: Discover providers via AEX for each subtask
+        await self._discover_providers(subtasks)
+
+        # Step 3: Execute subtasks via A2A
+        results = await self._execute_subtasks(subtasks)
+
+        # Step 4: Aggregate results
+        state["result"] = self._aggregate_results(user_content, subtasks)
+        state["artifacts"] = [
+            {
+                "name": "orchestration_report.json",
+                "parts": [{"type": "text", "text": json.dumps({
+                    "subtasks": [
+                        {
+                            "id": st.id,
+                            "description": st.description,
+                            "status": st.status,
+                            "provider": st.provider_id,
+                        }
+                        for st in subtasks
+                    ]
+                }, indent=2)}],
+            }
+        ]
+
+        return state
+
+    async def _decompose_task(self, user_request: str) -> list[SubTask]:
+        """Use LLM to decompose request into subtasks."""
+        if self.llm is None:
+            return self._mock_decompose(user_request)
+
+        try:
+            response = await self.llm.ainvoke([
+                SystemMessage(content=ORCHESTRATOR_PROMPT),
+                HumanMessage(content=user_request),
+            ])
+
+            # Parse JSON response
+            content = response.content.strip()
+            # Handle markdown code blocks
+            if content.startswith("```"):
+                content = content.split("```")[1]
+                if content.startswith("json"):
+                    content = content[4:]
+                content = content.strip()
+
+            data = json.loads(content)
+
+            subtasks = []
+            for st in data.get("subtasks", []):
+                subtasks.append(SubTask(
+                    id=st["id"],
+                    description=st["description"],
+                    skill_tags=st.get("skill_tags", []),
+                    input=st.get("input", ""),
+                    depends_on=st.get("depends_on", []),
+                ))
+
+            return subtasks
+
+        except Exception as e:
+            logger.exception(f"Error decomposing task: {e}")
+            return self._mock_decompose(user_request)
+
+    def _mock_decompose(self, user_request: str) -> list[SubTask]:
+        """Mock decomposition for testing."""
+        request_lower = user_request.lower()
+
+        subtasks = []
+        task_id = 1
+
+        # Basic contract review (Budget agent)
+        if "contract" in request_lower or "review" in request_lower or "nda" in request_lower:
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Review the contract for risks and obligations",
+                skill_tags=["contract_review", "legal"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+
+        # Compliance check (Standard agent)
+        if "compliance" in request_lower or "regulation" in request_lower or "gdpr" in request_lower:
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Check regulatory compliance",
+                skill_tags=["compliance_check", "legal"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+
+        # Negotiation support (Premium agent)
+        if "negotiate" in request_lower or "terms" in request_lower or "clause" in request_lower:
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Provide strategic negotiation recommendations",
+                skill_tags=["negotiation_support", "legal"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+
+        # Risk analysis (Premium agent)
+        if "risk" in request_lower or "assessment" in request_lower or "analysis" in request_lower:
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Perform detailed risk analysis with mitigation strategies",
+                skill_tags=["risk_analysis", "legal"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+
+        # Travel tasks
+        if "travel" in request_lower or "berlin" in request_lower or "flight" in request_lower:
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Find flight options",
+                skill_tags=["flight_booking", "travel"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+            subtasks.append(SubTask(
+                id=f"task_{task_id}",
+                description="Find hotel options",
+                skill_tags=["hotel_booking", "travel"],
+                input=user_request,
+                depends_on=[],
+            ))
+            task_id += 1
+
+        # Default: comprehensive review using all three agents
+        if not subtasks:
+            subtasks = [
+                SubTask(
+                    id="task_1",
+                    description="Quick contract overview",
+                    skill_tags=["contract_review", "legal"],
+                    input=user_request,
+                    depends_on=[],
+                ),
+                SubTask(
+                    id="task_2",
+                    description="Compliance verification",
+                    skill_tags=["compliance_check", "legal"],
+                    input=user_request,
+                    depends_on=[],
+                ),
+                SubTask(
+                    id="task_3",
+                    description="Strategic risk analysis and recommendations",
+                    skill_tags=["risk_analysis", "legal"],
+                    input=user_request,
+                    depends_on=[],
+                ),
+            ]
+
+        return subtasks
+
+    async def _discover_providers(self, subtasks: list[SubTask]):
+        """Discover providers via AEX for each subtask."""
+        # Demo agent URLs (Docker network hostnames)
+        # Each agent has different specialties to demonstrate multi-agent coordination
+        demo_agents = {
+            # Budget agent - quick basic reviews
+            "contract_review": ("http://legal-agent-a:8100", "Budget Legal Agent ($5+$2/page)"),
+            "legal": ("http://legal-agent-a:8100", "Budget Legal Agent ($5+$2/page)"),
+            # Standard agent - compliance and research
+            "legal_research": ("http://legal-agent-b:8101", "Standard Legal Agent ($15+$0.50/page)"),
+            "compliance_check": ("http://legal-agent-b:8101", "Standard Legal Agent ($15+$0.50/page)"),
+            "compliance": ("http://legal-agent-b:8101", "Standard Legal Agent ($15+$0.50/page)"),
+            # Premium agent - strategic advice and risk analysis
+            "negotiation_support": ("http://legal-agent-c:8102", "Premium Legal Agent ($30+$0.20/page)"),
+            "risk_analysis": ("http://legal-agent-c:8102", "Premium Legal Agent ($30+$0.20/page)"),
+            "negotiation": ("http://legal-agent-c:8102", "Premium Legal Agent ($30+$0.20/page)"),
+            "strategic": ("http://legal-agent-c:8102", "Premium Legal Agent ($30+$0.20/page)"),
+        }
+
+        for st in subtasks:
+            # Try AEX discovery first
+            if self.aex_client:
+                try:
+                    providers = await self.aex_client.search_providers(
+                        skill_tags=st.skill_tags,
+                    )
+                    if providers:
+                        st.provider_id = providers[0].get("provider_id")
+                        st.agent_url = providers[0].get("endpoint")
+                        logger.info(f"[AEX] Found provider {st.provider_id} for {st.id}")
+                        continue
+                except Exception as e:
+                    logger.warning(f"[AEX] Discovery failed for {st.id}: {e}")
+
+            # Fall back to demo agents
+            for tag in st.skill_tags:
+                if tag in demo_agents:
+                    st.agent_url, st.provider_id = demo_agents[tag]
+                    logger.info(f"[A2A] Using {st.provider_id} for subtask: {st.description}")
+                    break
+
+            # Default to budget legal agent
+            if not st.agent_url:
+                st.agent_url = "http://legal-agent-a:8100"
+                st.provider_id = "Budget Legal Agent ($5+$2/page)"
+                logger.info(f"[A2A] Default to {st.provider_id} for subtask: {st.description}")
+
+    async def _execute_subtasks(self, subtasks: list[SubTask]) -> dict[str, str]:
+        """Execute subtasks via A2A protocol."""
+        results = {}
+
+        async with aiohttp.ClientSession() as session:
+            for st in subtasks:
+                if not st.agent_url:
+                    st.status = "failed"
+                    st.result = "No provider available"
+                    continue
+
+                st.status = "running"
+                try:
+                    result = await self._call_a2a_agent(session, st)
+                    st.result = result
+                    st.status = "completed"
+                    results[st.id] = result
+                except Exception as e:
+                    logger.exception(f"Error executing {st.id}: {e}")
+                    st.status = "failed"
+                    st.result = str(e)
+
+        return results
+
+    async def _call_a2a_agent(self, session: aiohttp.ClientSession, subtask: SubTask) -> str:
+        """Call an agent via A2A JSON-RPC."""
+        a2a_url = f"{subtask.agent_url}/a2a"
+        logger.info(f"[A2A] Calling {subtask.provider_id} at {a2a_url}")
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "message/send",
+            "id": subtask.id,
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": subtask.input}],
+                }
+            },
+        }
+
+        try:
+            async with session.post(a2a_url, json=payload) as resp:
+                if resp.status != 200:
+                    error = await resp.text()
+                    raise Exception(f"A2A call failed: {error}")
+
+                data = await resp.json()
+
+                if "error" in data:
+                    raise Exception(data["error"].get("message", "Unknown error"))
+
+                result = data.get("result", {})
+                history = result.get("history", [])
+
+                # Extract agent response
+                for msg in reversed(history):
+                    if msg.get("role") == "agent":
+                        parts = msg.get("parts", [])
+                        for part in parts:
+                            if part.get("type") == "text":
+                                return part.get("text", "")
+
+                return "No response from agent"
+
+        except aiohttp.ClientError as e:
+            # If agent not reachable, return mock response
+            logger.warning(f"Could not reach agent at {a2a_url}: {e}")
+            return f"[Demo] Mock response for: {subtask.description}"
+
+    def _aggregate_results(self, original_request: str, subtasks: list[SubTask]) -> str:
+        """Aggregate results from all subtasks."""
+        lines = ["# Orchestration Results\n"]
+        lines.append(f"**Original Request**: {original_request}\n")
+        lines.append(f"**Subtasks Executed**: {len(subtasks)}\n")
+
+        # Agent Selection Summary
+        lines.append("\n## 📊 Agent Selection Summary\n")
+        lines.append("| Subtask | Skill Tags | Selected Agent | Selection Reason |")
+        lines.append("|---------|------------|----------------|------------------|")
+
+        for st in subtasks:
+            tags_str = ", ".join(st.skill_tags[:2]) if st.skill_tags else "N/A"
+            reason = self._get_selection_reason(st.skill_tags)
+            lines.append(f"| {st.description[:40]}... | `{tags_str}` | {st.provider_id or 'Unknown'} | {reason} |")
+
+        lines.append("\n---\n")
+
+        for st in subtasks:
+            status_icon = "✅" if st.status == "completed" else "❌"
+            lines.append(f"\n## {status_icon} {st.description}")
+            lines.append(f"**Provider**: {st.provider_id or 'Unknown'}")
+            lines.append(f"**Skill Tags**: {', '.join(st.skill_tags)}")
+            lines.append(f"**Status**: {st.status}\n")
+            if st.result:
+                lines.append(st.result)
+            lines.append("\n---")
+
+        return "\n".join(lines)
+
+    def _get_selection_reason(self, skill_tags: list[str]) -> str:
+        """Get reason for agent selection based on skill tags."""
+        reasons = {
+            "contract_review": "Basic review → Budget tier",
+            "legal": "General legal → Budget tier",
+            "compliance_check": "Compliance → Standard tier",
+            "legal_research": "Research → Standard tier",
+            "compliance": "Compliance → Standard tier",
+            "negotiation_support": "Negotiation → Premium tier",
+            "risk_analysis": "Risk analysis → Premium tier",
+            "negotiation": "Strategic → Premium tier",
+            "strategic": "Strategic → Premium tier",
+        }
+        for tag in skill_tags:
+            if tag in reasons:
+                return reasons[tag]
+        return "Default routing"

--- a/demo/agents/orchestrator/config.yaml
+++ b/demo/agents/orchestrator/config.yaml
@@ -1,0 +1,35 @@
+agent:
+  name: "Orchestrator Agent"
+  description: "Intelligent task orchestration using AEX for agent discovery and A2A for execution"
+  version: "1.0.0"
+  provider:
+    organization: "AEX Demo"
+    url: "https://github.com/open-experiments/agent-exchange"
+
+server:
+  host: "0.0.0.0"
+  port: 8103
+
+llm:
+  provider: "anthropic"
+  model: "claude-sonnet-4-20250514"
+  temperature: 0.5
+  max_tokens: 4096
+
+skills:
+  - id: "task_orchestration"
+    name: "Task Orchestration"
+    description: "Decompose complex requests and coordinate multiple agents"
+    tags: ["orchestration", "coordination"]
+    examples:
+      - "Plan my business trip and review the contract"
+      - "Help me prepare for the Berlin meeting"
+
+aex:
+  enabled: true
+  gateway_url: "http://aex-gateway:8080"
+  auto_register: false
+  auto_bid: false
+  pricing:
+    base_rate: 0.00
+    currency: "USD"

--- a/demo/agents/orchestrator/main.py
+++ b/demo/agents/orchestrator/main.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Orchestrator Agent - Main entry point."""
+
+import asyncio
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common.a2a_server import A2AServer
+from common.config import load_config
+from agent import OrchestratorAgent
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    """Start the Orchestrator Agent server."""
+    config_path = os.environ.get("CONFIG_PATH", "config.yaml")
+    config = load_config(config_path)
+
+    logger.info(f"Starting {config.name}")
+    logger.info(f"AEX Gateway: {config.aex.gateway_url}")
+
+    agent = OrchestratorAgent(config=config)
+
+    base_url = f"http://{config.server.host}:{config.server.port}"
+    if config.server.host == "0.0.0.0":
+        base_url = f"http://localhost:{config.server.port}"
+
+    agent_card = config.get_agent_card(base_url)
+
+    server = A2AServer(
+        agent_card=agent_card,
+        handler=agent,
+        require_auth=False,
+    )
+
+    logger.info(f"Agent Card: {base_url}/.well-known/agent-card.json")
+    logger.info(f"A2A Endpoint: {base_url}/a2a")
+    await server.run_async(host=config.server.host, port=config.server.port)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demo/agents/orchestrator/requirements.txt
+++ b/demo/agents/orchestrator/requirements.txt
@@ -1,0 +1,6 @@
+# Orchestrator Agent dependencies
+-r ../common/requirements.txt
+
+# Additional dependencies
+anthropic>=0.34.0
+httpx>=0.27.0

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,344 @@
+version: '3.8'
+
+services:
+  # ===========================================
+  # AEX Core Services
+  # ===========================================
+
+  mongo:
+    image: mongo:7
+    container_name: aex-mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    ports:
+      - "27017:27017"
+    volumes:
+      - aex_mongo_data:/data/db
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  aex-gateway:
+    build:
+      context: ../src
+      dockerfile: aex-gateway/Dockerfile
+    container_name: aex-gateway
+    environment:
+      PORT: "8080"
+      IDENTITY_URL: "http://aex-identity:8080"
+      BID_GATEWAY_URL: "http://aex-bid-gateway:8080"
+      PROVIDER_REGISTRY_URL: "http://aex-provider-registry:8080"
+      CONTRACT_ENGINE_URL: "http://aex-contract-engine:8080"
+      TRUST_BROKER_URL: "http://aex-trust-broker:8080"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - aex-identity
+      - aex-bid-gateway
+      - aex-provider-registry
+      - aex-contract-engine
+      - aex-trust-broker
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  aex-work-publisher:
+    build:
+      context: ../src
+      dockerfile: aex-work-publisher/Dockerfile
+    container_name: aex-work-publisher
+    environment:
+      PORT: "8080"
+      STORE_TYPE: "mongo"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+      MONGO_COLLECTION_WORK: "work_specs"
+      PROVIDER_REGISTRY_URL: "http://aex-provider-registry:8080"
+      ENVIRONMENT: "development"
+    ports:
+      - "8081:8080"
+    depends_on:
+      mongo:
+        condition: service_healthy
+      aex-provider-registry:
+        condition: service_started
+    networks:
+      - aex-network
+
+  aex-bid-gateway:
+    build:
+      context: ../src
+      dockerfile: aex-bid-gateway/Dockerfile
+    container_name: aex-bid-gateway
+    environment:
+      PORT: "8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+      PROVIDER_REGISTRY_URL: "http://aex-provider-registry:8080"
+    ports:
+      - "8082:8080"
+    depends_on:
+      - mongo
+      - aex-provider-registry
+    networks:
+      - aex-network
+
+  aex-bid-evaluator:
+    build:
+      context: ../src
+      dockerfile: aex-bid-evaluator/Dockerfile
+    container_name: aex-bid-evaluator
+    environment:
+      PORT: "8080"
+      BID_GATEWAY_URL: "http://aex-bid-gateway:8080"
+      TRUST_BROKER_URL: "http://aex-trust-broker:8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+    ports:
+      - "8083:8080"
+    depends_on:
+      - mongo
+      - aex-bid-gateway
+      - aex-trust-broker
+    networks:
+      - aex-network
+
+  aex-contract-engine:
+    build:
+      context: ../src
+      dockerfile: aex-contract-engine/Dockerfile
+    container_name: aex-contract-engine
+    environment:
+      PORT: "8080"
+      BID_GATEWAY_URL: "http://aex-bid-gateway:8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+    ports:
+      - "8084:8080"
+    depends_on:
+      - mongo
+      - aex-bid-gateway
+    networks:
+      - aex-network
+
+  aex-provider-registry:
+    build:
+      context: ../src
+      dockerfile: aex-provider-registry/Dockerfile
+    container_name: aex-provider-registry
+    environment:
+      PORT: "8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+      ENVIRONMENT: "development"
+    ports:
+      - "8085:8080"
+    depends_on:
+      - mongo
+    networks:
+      - aex-network
+
+  aex-trust-broker:
+    build:
+      context: ../src
+      dockerfile: aex-trust-broker/Dockerfile
+    container_name: aex-trust-broker
+    environment:
+      PORT: "8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+    ports:
+      - "8086:8080"
+    depends_on:
+      - mongo
+    networks:
+      - aex-network
+
+  aex-identity:
+    build:
+      context: ../src
+      dockerfile: aex-identity/Dockerfile
+    container_name: aex-identity
+    environment:
+      PORT: "8080"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+    ports:
+      - "8087:8080"
+    depends_on:
+      - mongo
+    networks:
+      - aex-network
+
+  aex-settlement:
+    build:
+      context: ../src
+      dockerfile: aex-settlement/Dockerfile
+    container_name: aex-settlement
+    environment:
+      PORT: "8080"
+      ENVIRONMENT: "development"
+      MONGO_URI: "mongodb://root:root@mongo:27017/?authSource=admin"
+      MONGO_DB: "aex"
+    ports:
+      - "8088:8080"
+    depends_on:
+      mongo:
+        condition: service_healthy
+    networks:
+      - aex-network
+
+  aex-telemetry:
+    build:
+      context: ../src
+      dockerfile: aex-telemetry/Dockerfile
+    container_name: aex-telemetry
+    environment:
+      PORT: "8080"
+    ports:
+      - "8089:8080"
+    networks:
+      - aex-network
+
+  # ===========================================
+  # Demo Legal Agents (Tiered Pricing)
+  # ===========================================
+
+  # Budget Legal Agent - $5 + $2/page, fast, concise analysis (Claude)
+  legal-agent-a:
+    build:
+      context: ./agents
+      dockerfile: Dockerfile
+      args:
+        AGENT_DIR: legal-agent-a
+    container_name: aex-legal-agent-a
+    ports:
+      - "8100:8100"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AEX_GATEWAY_URL=http://aex-gateway:8080
+      - AEX_API_KEY=dev-api-key
+      - AGENT_HOSTNAME=legal-agent-a
+      - CONFIG_PATH=config.yaml
+    depends_on:
+      - aex-gateway
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8100/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Standard Legal Agent - $15 + $0.50/page, thorough analysis (Claude)
+  legal-agent-b:
+    build:
+      context: ./agents
+      dockerfile: Dockerfile
+      args:
+        AGENT_DIR: legal-agent-b
+    container_name: aex-legal-agent-b
+    ports:
+      - "8101:8101"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AEX_GATEWAY_URL=http://aex-gateway:8080
+      - AEX_API_KEY=dev-api-key
+      - AGENT_HOSTNAME=legal-agent-b
+      - CONFIG_PATH=config.yaml
+    depends_on:
+      - aex-gateway
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8101/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Premium Legal Agent - $30 + $0.20/page, exhaustive expert analysis (Claude)
+  legal-agent-c:
+    build:
+      context: ./agents
+      dockerfile: Dockerfile
+      args:
+        AGENT_DIR: legal-agent-c
+    container_name: aex-legal-agent-c
+    ports:
+      - "8102:8102"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AEX_GATEWAY_URL=http://aex-gateway:8080
+      - AEX_API_KEY=dev-api-key
+      - AGENT_HOSTNAME=legal-agent-c
+      - CONFIG_PATH=config.yaml
+    depends_on:
+      - aex-gateway
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8102/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  orchestrator:
+    build:
+      context: ./agents
+      dockerfile: Dockerfile
+      args:
+        AGENT_DIR: orchestrator
+    container_name: aex-orchestrator
+    ports:
+      - "8103:8103"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AEX_GATEWAY_URL=http://aex-gateway:8080
+      - AEX_API_KEY=dev-api-key
+      - CONFIG_PATH=config.yaml
+    depends_on:
+      - aex-gateway
+      - legal-agent-a
+      - legal-agent-b
+      - legal-agent-c
+    networks:
+      - aex-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8103/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  demo-ui:
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
+    container_name: aex-demo-ui
+    ports:
+      - "8501:8501"
+    environment:
+      - ORCHESTRATOR_URL=http://orchestrator:8103
+      - LEGAL_AGENT_A_URL=http://legal-agent-a:8100
+      - LEGAL_AGENT_B_URL=http://legal-agent-b:8101
+      - LEGAL_AGENT_C_URL=http://legal-agent-c:8102
+    depends_on:
+      - orchestrator
+    networks:
+      - aex-network
+
+volumes:
+  aex_mongo_data:
+
+networks:
+  aex-network:
+    driver: bridge

--- a/demo/ui/Dockerfile
+++ b/demo/ui/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application
+COPY main.py .
+
+# Expose port
+EXPOSE 8501
+
+# Run the UI with gunicorn (mesop binds to localhost by default, gunicorn allows 0.0.0.0)
+CMD ["gunicorn", "--bind", "0.0.0.0:8501", "main:me"]

--- a/demo/ui/main.py
+++ b/demo/ui/main.py
@@ -1,0 +1,333 @@
+"""AEX + A2A Demo UI using Mesop."""
+
+import json
+import os
+import httpx
+import mesop as me
+
+
+# Configuration - read from environment or use defaults
+ORCHESTRATOR_URL = os.environ.get("ORCHESTRATOR_URL", "http://localhost:8103")
+LEGAL_AGENT_A_URL = os.environ.get("LEGAL_AGENT_A_URL", "http://localhost:8100")
+LEGAL_AGENT_B_URL = os.environ.get("LEGAL_AGENT_B_URL", "http://localhost:8101")
+LEGAL_AGENT_C_URL = os.environ.get("LEGAL_AGENT_C_URL", "http://localhost:8102")
+
+
+from dataclasses import field
+
+
+@me.stateclass
+class State:
+    """Application state."""
+    user_input: str = ""
+    response: str = ""
+    loading: bool = False
+    selected_agent: str = "orchestrator"
+    agent_status: dict = field(default_factory=dict)
+    error: str = ""
+
+
+def get_agent_url(agent: str) -> str:
+    """Get URL for selected agent."""
+    urls = {
+        "orchestrator": ORCHESTRATOR_URL,
+        "legal_a": LEGAL_AGENT_A_URL,
+        "legal_b": LEGAL_AGENT_B_URL,
+        "legal_c": LEGAL_AGENT_C_URL,
+    }
+    return urls.get(agent, ORCHESTRATOR_URL)
+
+
+def call_agent(url: str, message: str) -> str:
+    """Call an agent via A2A protocol."""
+    a2a_url = f"{url}/a2a"
+
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "message/send",
+        "id": "demo-1",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"type": "text", "text": message}],
+            }
+        },
+    }
+
+    try:
+        with httpx.Client(timeout=120.0) as client:
+            resp = client.post(a2a_url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+            if "error" in data:
+                return f"Error: {data['error'].get('message', 'Unknown error')}"
+
+            result = data.get("result", {})
+            history = result.get("history", [])
+
+            # Extract agent response
+            for msg in reversed(history):
+                if msg.get("role") == "agent":
+                    parts = msg.get("parts", [])
+                    for part in parts:
+                        if part.get("type") == "text":
+                            return part.get("text", "No text response")
+
+            return "No response from agent"
+
+    except httpx.HTTPError as e:
+        return f"HTTP Error: {str(e)}"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+def check_agent_health(url: str) -> bool:
+    """Check if an agent is healthy."""
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{url}/health")
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def on_input_change(e: me.InputEvent):
+    """Handle input change."""
+    state = me.state(State)
+    state.user_input = e.value
+
+
+def on_agent_select(e: me.SelectSelectionChangeEvent):
+    """Handle agent selection."""
+    state = me.state(State)
+    state.selected_agent = e.value
+
+
+def on_submit(e: me.ClickEvent):
+    """Handle form submission."""
+    state = me.state(State)
+    if not state.user_input.strip():
+        state.error = "Please enter a message"
+        return
+
+    state.loading = True
+    state.error = ""
+    state.response = ""
+
+    # Call selected agent
+    url = get_agent_url(state.selected_agent)
+    state.response = call_agent(url, state.user_input)
+    state.loading = False
+
+
+def on_check_status(e: me.ClickEvent):
+    """Check status of all agents."""
+    state = me.state(State)
+    agents = {
+        "Orchestrator": ORCHESTRATOR_URL,
+        "Budget Legal": LEGAL_AGENT_A_URL,
+        "Standard Legal": LEGAL_AGENT_B_URL,
+        "Premium Legal": LEGAL_AGENT_C_URL,
+    }
+
+    status = {}
+    for name, url in agents.items():
+        status[name] = "Online" if check_agent_health(url) else "Offline"
+
+    state.agent_status = status
+
+
+def on_clear(e: me.ClickEvent):
+    """Clear the response."""
+    state = me.state(State)
+    state.response = ""
+    state.error = ""
+
+
+@me.page(path="/")
+def home():
+    """Main demo page."""
+    state = me.state(State)
+
+    with me.box(style=me.Style(
+        padding=me.Padding.all(24),
+        max_width=1200,
+        margin=me.Margin.symmetric(horizontal="auto"),
+    )):
+        # Header
+        me.text(
+            "Agent Exchange + A2A Demo",
+            style=me.Style(
+                font_size=32,
+                font_weight="bold",
+                margin=me.Margin(bottom=8),
+            ),
+        )
+        me.text(
+            "Intelligent agent discovery and orchestration",
+            style=me.Style(
+                font_size=16,
+                color="#666",
+                margin=me.Margin(bottom=24),
+            ),
+        )
+
+        # Agent status section
+        with me.box(style=me.Style(
+            background="#f5f5f5",
+            padding=me.Padding.all(16),
+            border_radius=8,
+            margin=me.Margin(bottom=24),
+        )):
+            with me.box(style=me.Style(
+                display="flex",
+                justify_content="space-between",
+                align_items="center",
+                margin=me.Margin(bottom=12),
+            )):
+                me.text("Agent Status", style=me.Style(font_weight="bold"))
+                me.button("Check Status", on_click=on_check_status, type="flat")
+
+            if state.agent_status:
+                with me.box(style=me.Style(display="flex", gap=16)):
+                    for name, status in state.agent_status.items():
+                        color = "#4caf50" if status == "Online" else "#f44336"
+                        with me.box(style=me.Style(
+                            padding=me.Padding.all(8),
+                            background="white",
+                            border_radius=4,
+                            min_width=120,
+                        )):
+                            me.text(name, style=me.Style(font_size=12, color="#666"))
+                            me.text(status, style=me.Style(color=color, font_weight="bold"))
+
+        # Input section
+        with me.box(style=me.Style(margin=me.Margin(bottom=24))):
+            me.text("Select Agent:", style=me.Style(margin=me.Margin(bottom=8)))
+            me.select(
+                value=state.selected_agent,
+                options=[
+                    me.SelectOption(label="Orchestrator (Multi-agent)", value="orchestrator"),
+                    me.SelectOption(label="Budget Legal ($5 + $2/page)", value="legal_a"),
+                    me.SelectOption(label="Standard Legal ($15 + $0.50/page)", value="legal_b"),
+                    me.SelectOption(label="Premium Legal ($30 + $0.20/page)", value="legal_c"),
+                ],
+                on_selection_change=on_agent_select,
+                style=me.Style(width=300, margin=me.Margin(bottom=16)),
+            )
+
+            me.text("Your Request:", style=me.Style(margin=me.Margin(bottom=8)))
+            me.textarea(
+                value=state.user_input,
+                on_input=on_input_change,
+                placeholder="e.g., Review this NDA for potential risks. Focus on liability clauses, termination conditions, and intellectual property provisions.",
+                style=me.Style(width="100%", min_height=100),
+            )
+
+            with me.box(style=me.Style(
+                display="flex",
+                gap=12,
+                margin=me.Margin(top=16),
+            )):
+                me.button(
+                    "Send Request",
+                    on_click=on_submit,
+                    disabled=state.loading,
+                    type="raised",
+                )
+                me.button(
+                    "Clear",
+                    on_click=on_clear,
+                    type="flat",
+                )
+
+            if state.loading:
+                me.progress_spinner()
+
+        # Error display
+        if state.error:
+            with me.box(style=me.Style(
+                background="#ffebee",
+                color="#c62828",
+                padding=me.Padding.all(12),
+                border_radius=4,
+                margin=me.Margin(bottom=16),
+            )):
+                me.text(state.error)
+
+        # Response section
+        if state.response:
+            with me.box(style=me.Style(
+                background="white",
+                border=me.Border.all(me.BorderSide(width=1, color="#e0e0e0")),
+                border_radius=8,
+                padding=me.Padding.all(20),
+            )):
+                me.text(
+                    "Response",
+                    style=me.Style(
+                        font_weight="bold",
+                        font_size=18,
+                        margin=me.Margin(bottom=16),
+                    ),
+                )
+                me.markdown(state.response)
+
+        # Demo scenarios
+        with me.box(style=me.Style(margin=me.Margin(top=32))):
+            me.text(
+                "Example Scenarios",
+                style=me.Style(
+                    font_weight="bold",
+                    font_size=18,
+                    margin=me.Margin(bottom=16),
+                ),
+            )
+
+            scenarios = [
+                {
+                    "title": "Multi-Agent Contract Analysis",
+                    "description": "I need a comprehensive review of this partnership agreement. Compare different analysis approaches and recommend the best value option.",
+                    "agent": "orchestrator",
+                },
+                {
+                    "title": "Quick NDA Review (Budget)",
+                    "description": "Review this NDA for potential risks: [Standard NDA with 2-year term, broad definition of confidential information, and no carve-outs for public information]",
+                    "agent": "legal_a",
+                },
+                {
+                    "title": "GDPR Compliance Check (Standard)",
+                    "description": "Check if our privacy policy complies with GDPR. We collect email, name, and usage data for analytics.",
+                    "agent": "legal_b",
+                },
+                {
+                    "title": "Complex IP Agreement (Premium)",
+                    "description": "Provide exhaustive analysis of this intellectual property licensing agreement including jurisdiction-specific considerations and negotiation recommendations.",
+                    "agent": "legal_c",
+                },
+            ]
+
+            with me.box(style=me.Style(
+                display="grid",
+                grid_template_columns="repeat(2, 1fr)",
+                gap=16,
+            )):
+                for scenario in scenarios:
+                    with me.box(style=me.Style(
+                        background="#f9f9f9",
+                        padding=me.Padding.all(16),
+                        border_radius=8,
+                        cursor="pointer",
+                    )):
+                        me.text(
+                            scenario["title"],
+                            style=me.Style(font_weight="bold", margin=me.Margin(bottom=8)),
+                        )
+                        me.text(
+                            scenario["description"][:100] + "..." if len(scenario["description"]) > 100 else scenario["description"],
+                            style=me.Style(font_size=14, color="#666"),
+                        )
+
+
+# App is started via mesop CLI: mesop main.py --port=8501

--- a/demo/ui/requirements.txt
+++ b/demo/ui/requirements.txt
@@ -1,0 +1,5 @@
+# Demo UI dependencies
+mesop>=0.12.0
+aiohttp>=3.9.0
+httpx>=0.27.0
+gunicorn>=21.0.0

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,193 @@
+# GCP Deployment Guide
+
+This guide explains how to deploy Agent Exchange (AEX) and demo agents to Google Cloud Platform using Cloud Run.
+
+## Prerequisites
+
+1. **GCP Project** with billing enabled
+2. **gcloud CLI** installed and authenticated
+3. **API Keys** for LLM providers:
+   - Anthropic API Key (for Claude - used by Legal Agent A and Orchestrator)
+   - Google AI API Key (for Gemini - used by Legal Agent B and Travel Agent)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              GCP Cloud Run                                   │
+│                                                                             │
+│  ┌─────────────┐    ┌─────────────────────────────────────────────────┐    │
+│  │   Demo UI   │───▶│                  AEX Gateway                    │    │
+│  └─────────────┘    └────────────────────────────────────────────────┘    │
+│         │                              │                                    │
+│         │           ┌──────────────────┼──────────────────┐                │
+│         │           │                  │                  │                │
+│         ▼           ▼                  ▼                  ▼                │
+│  ┌─────────────┐ ┌─────────┐ ┌─────────────┐ ┌─────────────────┐          │
+│  │ Orchestrator│ │Work Pub │ │Bid Gateway  │ │Provider Registry│          │
+│  └─────────────┘ └─────────┘ └─────────────┘ └─────────────────┘          │
+│         │                                              │                   │
+│         │ A2A                            Skill Search  │                   │
+│         ▼                                              │                   │
+│  ┌──────────────────────────────────────────────────┐ │                   │
+│  │              Provider Agents (A2A)                │◀┘                   │
+│  │  ┌────────────┐ ┌────────────┐ ┌────────────┐   │                     │
+│  │  │Legal A     │ │Legal B     │ │Travel      │   │                     │
+│  │  │(Claude)    │ │(Gemini)    │ │(Gemini)    │   │                     │
+│  │  └────────────┘ └────────────┘ └────────────┘   │                     │
+│  └──────────────────────────────────────────────────┘                     │
+│                                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                         Secret Manager                               │   │
+│  │         ANTHROPIC_API_KEY  |  GOOGLE_AI_API_KEY                     │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### 1. Set up your project
+
+```bash
+# Set your project ID
+export PROJECT_ID="your-project-id"
+export REGION="us-central1"
+
+# Authenticate
+gcloud auth login
+gcloud config set project $PROJECT_ID
+```
+
+### 2. Deploy everything
+
+```bash
+cd deploy/gcp
+./deploy.sh $PROJECT_ID $REGION
+```
+
+### 3. Configure API keys
+
+After deployment, update the secrets with your actual API keys:
+
+```bash
+# Anthropic (Claude) - for Legal Agent A and Orchestrator
+echo "sk-ant-..." | gcloud secrets versions add ANTHROPIC_API_KEY --data-file=-
+
+# Google AI (Gemini) - for Legal Agent B and Travel Agent
+echo "AI..." | gcloud secrets versions add GOOGLE_AI_API_KEY --data-file=-
+```
+
+### 4. Access the demo
+
+The deploy script will output the Demo UI URL. Open it in your browser to try the demo.
+
+## Manual Deployment
+
+If you prefer to deploy services individually:
+
+### Build images
+
+```bash
+# Build with Cloud Build
+gcloud builds submit --config=deploy/gcp/cloudbuild.yaml .
+```
+
+### Deploy a single service
+
+```bash
+gcloud run deploy aex-gateway \
+    --image gcr.io/$PROJECT_ID/aex-gateway:latest \
+    --region $REGION \
+    --platform managed \
+    --allow-unauthenticated
+```
+
+## Environment Variables
+
+### AEX Services
+
+| Service | Required Variables |
+|---------|-------------------|
+| aex-gateway | WORK_PUBLISHER_URL, BID_GATEWAY_URL, etc. |
+| aex-provider-registry | MONGO_URI (optional) |
+| aex-work-publisher | PROVIDER_REGISTRY_URL |
+| aex-bid-gateway | PROVIDER_REGISTRY_URL |
+| aex-bid-evaluator | BID_GATEWAY_URL, TRUST_BROKER_URL |
+| aex-contract-engine | BID_GATEWAY_URL, WORK_PUBLISHER_URL |
+| aex-settlement | CONTRACT_ENGINE_URL, TRUST_BROKER_URL |
+
+### Demo Agents
+
+| Agent | LLM | Required Secrets |
+|-------|-----|-----------------|
+| legal-agent-a | Claude | ANTHROPIC_API_KEY |
+| legal-agent-b | Gemini | GOOGLE_AI_API_KEY |
+| travel-agent | Gemini | GOOGLE_AI_API_KEY |
+| orchestrator | Claude | ANTHROPIC_API_KEY |
+
+## Cost Optimization
+
+- All services use **min-instances: 0** to scale to zero when idle
+- Services auto-scale based on traffic
+- Memory is set conservatively (512Mi-1Gi)
+
+To reduce costs further:
+```bash
+# Set all services to min-instances 0
+for service in aex-gateway aex-provider-registry legal-agent-a; do
+    gcloud run services update $service --min-instances 0 --region $REGION
+done
+```
+
+## Monitoring
+
+View logs in Cloud Console:
+```bash
+gcloud logging read "resource.type=cloud_run_revision" --limit 50
+```
+
+Or use the Cloud Console: https://console.cloud.google.com/run
+
+## Cleanup
+
+To delete all deployed services:
+
+```bash
+# Delete Cloud Run services
+for service in demo-ui orchestrator travel-agent legal-agent-b legal-agent-a \
+    aex-gateway aex-telemetry aex-identity aex-settlement aex-contract-engine \
+    aex-bid-evaluator aex-trust-broker aex-bid-gateway aex-work-publisher \
+    aex-provider-registry; do
+    gcloud run services delete $service --region $REGION --quiet
+done
+
+# Delete container images
+gcloud container images list --repository gcr.io/$PROJECT_ID | \
+    xargs -I {} gcloud container images delete {} --force-delete-tags --quiet
+```
+
+## Troubleshooting
+
+### Service not starting
+
+Check logs:
+```bash
+gcloud run services logs read aex-gateway --region $REGION
+```
+
+### Secret not found
+
+Ensure secrets are created:
+```bash
+gcloud secrets list
+```
+
+### Connection refused between services
+
+Ensure services allow unauthenticated access:
+```bash
+gcloud run services add-iam-policy-binding SERVICE_NAME \
+    --member="allUsers" \
+    --role="roles/run.invoker" \
+    --region $REGION
+```

--- a/deploy/gcp/cloudbuild.yaml
+++ b/deploy/gcp/cloudbuild.yaml
@@ -1,0 +1,134 @@
+# Cloud Build configuration for AEX services
+# Deploy to Cloud Run with Firestore backend
+
+steps:
+  # Build AEX services
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-gateway:$COMMIT_SHA', '-f', 'src/aex-gateway/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-provider-registry:$COMMIT_SHA', '-f', 'src/aex-provider-registry/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-work-publisher:$COMMIT_SHA', '-f', 'src/aex-work-publisher/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-bid-gateway:$COMMIT_SHA', '-f', 'src/aex-bid-gateway/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-bid-evaluator:$COMMIT_SHA', '-f', 'src/aex-bid-evaluator/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-contract-engine:$COMMIT_SHA', '-f', 'src/aex-contract-engine/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-settlement:$COMMIT_SHA', '-f', 'src/aex-settlement/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-trust-broker:$COMMIT_SHA', '-f', 'src/aex-trust-broker/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-identity:$COMMIT_SHA', '-f', 'src/aex-identity/Dockerfile', '.']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/aex-telemetry:$COMMIT_SHA', '-f', 'src/aex-telemetry/Dockerfile', '.']
+    dir: '.'
+
+  # Build demo agents
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/legal-agent-a:$COMMIT_SHA', '--build-arg', 'AGENT_DIR=legal-agent-a', '-f', 'demo/agents/Dockerfile', 'demo/agents']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/legal-agent-b:$COMMIT_SHA', '--build-arg', 'AGENT_DIR=legal-agent-b', '-f', 'demo/agents/Dockerfile', 'demo/agents']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/legal-agent-c:$COMMIT_SHA', '--build-arg', 'AGENT_DIR=legal-agent-c', '-f', 'demo/agents/Dockerfile', 'demo/agents']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/orchestrator:$COMMIT_SHA', '--build-arg', 'AGENT_DIR=orchestrator', '-f', 'demo/agents/Dockerfile', 'demo/agents']
+    dir: '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/demo-ui:$COMMIT_SHA', '-f', 'demo/ui/Dockerfile', 'demo/ui']
+    dir: '.'
+
+  # Push all images
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-gateway']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-provider-registry']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-work-publisher']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-bid-gateway']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-bid-evaluator']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-contract-engine']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-settlement']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-trust-broker']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-identity']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/aex-telemetry']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/legal-agent-a']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/legal-agent-b']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/legal-agent-c']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/orchestrator']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'gcr.io/$PROJECT_ID/demo-ui']
+
+images:
+  - 'gcr.io/$PROJECT_ID/aex-gateway:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-provider-registry:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-work-publisher:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-bid-gateway:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-bid-evaluator:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-contract-engine:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-settlement:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-trust-broker:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-identity:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/aex-telemetry:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/legal-agent-a:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/legal-agent-b:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/legal-agent-c:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/orchestrator:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/demo-ui:$COMMIT_SHA'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'
+
+timeout: '1800s'

--- a/deploy/gcp/deploy.sh
+++ b/deploy/gcp/deploy.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+# Deploy AEX and demo agents to GCP Cloud Run
+# Usage: ./deploy.sh <project-id> <region>
+
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+REGION="${2:-us-central1}"
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "Usage: $0 <project-id> [region]"
+    echo "Example: $0 my-gcp-project us-central1"
+    exit 1
+fi
+
+echo "Deploying to project: $PROJECT_ID, region: $REGION"
+
+# Set project
+gcloud config set project "$PROJECT_ID"
+
+# Enable required APIs
+echo "Enabling required APIs..."
+gcloud services enable \
+    cloudbuild.googleapis.com \
+    run.googleapis.com \
+    secretmanager.googleapis.com \
+    firestore.googleapis.com \
+    --quiet
+
+# Create secrets if they don't exist
+echo "Setting up secrets..."
+for secret in ANTHROPIC_API_KEY MONGO_URI JWT_SIGNING_KEY; do
+    if ! gcloud secrets describe "$secret" --quiet 2>/dev/null; then
+        echo "Creating secret: $secret"
+        echo "placeholder" | gcloud secrets create "$secret" --data-file=- --quiet
+        echo "⚠️  Please update secret $secret with actual value:"
+        echo "   gcloud secrets versions add $secret --data-file=-"
+    fi
+done
+
+# Build images using Cloud Build
+echo "Building images..."
+gcloud builds submit --config=deploy/gcp/cloudbuild.yaml .
+
+# Get the latest image tag
+COMMIT_SHA=$(git rev-parse HEAD)
+
+# Deploy AEX core services
+echo "Deploying AEX services..."
+
+# Provider Registry
+gcloud run deploy aex-provider-registry \
+    --image "gcr.io/$PROJECT_ID/aex-provider-registry:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "MONGO_URI=projects/$PROJECT_ID/secrets/MONGO_URI:latest" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --quiet
+
+PROVIDER_REGISTRY_URL=$(gcloud run services describe aex-provider-registry --region "$REGION" --format 'value(status.url)')
+
+# Work Publisher
+gcloud run deploy aex-work-publisher \
+    --image "gcr.io/$PROJECT_ID/aex-work-publisher:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "PROVIDER_REGISTRY_URL=$PROVIDER_REGISTRY_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --quiet
+
+WORK_PUBLISHER_URL=$(gcloud run services describe aex-work-publisher --region "$REGION" --format 'value(status.url)')
+
+# Bid Gateway
+gcloud run deploy aex-bid-gateway \
+    --image "gcr.io/$PROJECT_ID/aex-bid-gateway:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "PROVIDER_REGISTRY_URL=$PROVIDER_REGISTRY_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --quiet
+
+BID_GATEWAY_URL=$(gcloud run services describe aex-bid-gateway --region "$REGION" --format 'value(status.url)')
+
+# Trust Broker
+gcloud run deploy aex-trust-broker \
+    --image "gcr.io/$PROJECT_ID/aex-trust-broker:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+TRUST_BROKER_URL=$(gcloud run services describe aex-trust-broker --region "$REGION" --format 'value(status.url)')
+
+# Bid Evaluator
+gcloud run deploy aex-bid-evaluator \
+    --image "gcr.io/$PROJECT_ID/aex-bid-evaluator:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "BID_GATEWAY_URL=$BID_GATEWAY_URL,TRUST_BROKER_URL=$TRUST_BROKER_URL,WORK_PUBLISHER_URL=$WORK_PUBLISHER_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --quiet
+
+BID_EVALUATOR_URL=$(gcloud run services describe aex-bid-evaluator --region "$REGION" --format 'value(status.url)')
+
+# Contract Engine
+gcloud run deploy aex-contract-engine \
+    --image "gcr.io/$PROJECT_ID/aex-contract-engine:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "BID_GATEWAY_URL=$BID_GATEWAY_URL,WORK_PUBLISHER_URL=$WORK_PUBLISHER_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 10 \
+    --quiet
+
+CONTRACT_ENGINE_URL=$(gcloud run services describe aex-contract-engine --region "$REGION" --format 'value(status.url)')
+
+# Settlement
+gcloud run deploy aex-settlement \
+    --image "gcr.io/$PROJECT_ID/aex-settlement:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "CONTRACT_ENGINE_URL=$CONTRACT_ENGINE_URL,TRUST_BROKER_URL=$TRUST_BROKER_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+SETTLEMENT_URL=$(gcloud run services describe aex-settlement --region "$REGION" --format 'value(status.url)')
+
+# Identity
+gcloud run deploy aex-identity \
+    --image "gcr.io/$PROJECT_ID/aex-identity:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+IDENTITY_URL=$(gcloud run services describe aex-identity --region "$REGION" --format 'value(status.url)')
+
+# Telemetry
+gcloud run deploy aex-telemetry \
+    --image "gcr.io/$PROJECT_ID/aex-telemetry:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+TELEMETRY_URL=$(gcloud run services describe aex-telemetry --region "$REGION" --format 'value(status.url)')
+
+# Gateway (main entry point)
+gcloud run deploy aex-gateway \
+    --image "gcr.io/$PROJECT_ID/aex-gateway:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "\
+WORK_PUBLISHER_URL=$WORK_PUBLISHER_URL,\
+BID_GATEWAY_URL=$BID_GATEWAY_URL,\
+BID_EVALUATOR_URL=$BID_EVALUATOR_URL,\
+CONTRACT_ENGINE_URL=$CONTRACT_ENGINE_URL,\
+SETTLEMENT_URL=$SETTLEMENT_URL,\
+PROVIDER_REGISTRY_URL=$PROVIDER_REGISTRY_URL,\
+TRUST_BROKER_URL=$TRUST_BROKER_URL,\
+IDENTITY_URL=$IDENTITY_URL,\
+TELEMETRY_URL=$TELEMETRY_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 1 \
+    --max-instances 20 \
+    --quiet
+
+AEX_GATEWAY_URL=$(gcloud run services describe aex-gateway --region "$REGION" --format 'value(status.url)')
+
+echo ""
+echo "=== AEX Services Deployed ==="
+echo "Gateway URL: $AEX_GATEWAY_URL"
+echo ""
+
+# Deploy demo agents
+echo "Deploying demo agents..."
+
+# Legal Agent A (Budget - uses Claude)
+gcloud run deploy legal-agent-a \
+    --image "gcr.io/$PROJECT_ID/legal-agent-a:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-secrets "ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+    --set-env-vars "AEX_GATEWAY_URL=$AEX_GATEWAY_URL" \
+    --memory 1Gi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+LEGAL_A_URL=$(gcloud run services describe legal-agent-a --region "$REGION" --format 'value(status.url)')
+
+# Legal Agent B (Standard - uses Claude)
+gcloud run deploy legal-agent-b \
+    --image "gcr.io/$PROJECT_ID/legal-agent-b:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-secrets "ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+    --set-env-vars "AEX_GATEWAY_URL=$AEX_GATEWAY_URL" \
+    --memory 1Gi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+LEGAL_B_URL=$(gcloud run services describe legal-agent-b --region "$REGION" --format 'value(status.url)')
+
+# Legal Agent C (Premium - uses Claude)
+gcloud run deploy legal-agent-c \
+    --image "gcr.io/$PROJECT_ID/legal-agent-c:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-secrets "ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+    --set-env-vars "AEX_GATEWAY_URL=$AEX_GATEWAY_URL" \
+    --memory 1Gi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+LEGAL_C_URL=$(gcloud run services describe legal-agent-c --region "$REGION" --format 'value(status.url)')
+
+# Orchestrator
+gcloud run deploy orchestrator \
+    --image "gcr.io/$PROJECT_ID/orchestrator:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-secrets "ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+    --set-env-vars "AEX_GATEWAY_URL=$AEX_GATEWAY_URL,LEGAL_AGENT_A_URL=$LEGAL_A_URL,LEGAL_AGENT_B_URL=$LEGAL_B_URL,LEGAL_AGENT_C_URL=$LEGAL_C_URL" \
+    --memory 1Gi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+ORCHESTRATOR_URL=$(gcloud run services describe orchestrator --region "$REGION" --format 'value(status.url)')
+
+# Demo UI
+gcloud run deploy demo-ui \
+    --image "gcr.io/$PROJECT_ID/demo-ui:$COMMIT_SHA" \
+    --region "$REGION" \
+    --platform managed \
+    --allow-unauthenticated \
+    --set-env-vars "ORCHESTRATOR_URL=$ORCHESTRATOR_URL,LEGAL_AGENT_A_URL=$LEGAL_A_URL,LEGAL_AGENT_B_URL=$LEGAL_B_URL,LEGAL_AGENT_C_URL=$LEGAL_C_URL" \
+    --memory 512Mi \
+    --cpu 1 \
+    --min-instances 0 \
+    --max-instances 5 \
+    --quiet
+
+DEMO_UI_URL=$(gcloud run services describe demo-ui --region "$REGION" --format 'value(status.url)')
+
+echo ""
+echo "========================================="
+echo "         DEPLOYMENT COMPLETE"
+echo "========================================="
+echo ""
+echo "AEX Gateway:     $AEX_GATEWAY_URL"
+echo ""
+echo "Demo Legal Agents (with tiered pricing):"
+echo "  Legal Agent A (Budget):   $LEGAL_A_URL"
+echo "    - Base: \$5 + \$2/page (best for 1-5 pages)"
+echo "  Legal Agent B (Standard): $LEGAL_B_URL"
+echo "    - Base: \$15 + \$0.50/page (best for 5-30 pages)"
+echo "  Legal Agent C (Premium):  $LEGAL_C_URL"
+echo "    - Base: \$30 + \$0.20/page (best for 30+ pages)"
+echo "  Orchestrator:             $ORCHESTRATOR_URL"
+echo ""
+echo "Demo UI:         $DEMO_UI_URL"
+echo ""
+echo "========================================="
+echo ""
+echo "Next steps:"
+echo "1. Update API key secret:"
+echo "   echo 'your-key' | gcloud secrets versions add ANTHROPIC_API_KEY --data-file=-"
+echo ""
+echo "2. Open the demo UI: $DEMO_UI_URL"
+echo ""

--- a/documents/a2a-integration/AEX_A2A_INTEGRATION_ROADMAP.md
+++ b/documents/a2a-integration/AEX_A2A_INTEGRATION_ROADMAP.md
@@ -1,0 +1,623 @@
+# Agent Exchange (AEX) - A2A Integration Roadmap
+
+**Version:** 1.0
+**Date:** January 2, 2026
+**Status:** PROPOSAL
+
+---
+
+## 1. Executive Summary
+
+This document outlines the integration strategy between **Agent Exchange (AEX)** and the **Agent2Agent (A2A) Protocol** to create a comprehensive agent marketplace with intelligent discovery, bidding, and execution capabilities.
+
+### Vision
+AEX becomes the **curated marketplace layer** for A2A agents, providing:
+- **Smart Discovery**: Find the best agent for a task based on skills, trust, and pricing
+- **Competitive Bidding**: Multiple agents bid on work, ensuring best value
+- **Trust & Reputation**: Track agent performance over time
+- **Settlement**: Handle payments between consumers and providers
+- **Direct Execution**: After contract award, agents communicate directly via A2A
+
+### Key Value Proposition
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         CURRENT A2A LIMITATION                          │
+│  Consumer must know which agent to call → No discovery/comparison       │
+├─────────────────────────────────────────────────────────────────────────┤
+│                      AEX + A2A SOLUTION                                 │
+│  Consumer describes task → AEX finds best agents → Bidding →            │
+│  Award → Direct A2A execution → Settlement                              │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 High-Level Integration
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              DEMONSTRATION FLOW                               │
+│                                                                              │
+│  ┌─────────────┐     ┌─────────────────────────────────────┐                 │
+│  │   User UI   │     │        Agent Exchange (AEX)         │                 │
+│  │  (Mesop)    │     │  ┌─────────┐  ┌──────────────────┐  │                 │
+│  └──────┬──────┘     │  │Registry │  │  Bid Evaluator   │  │                 │
+│         │            │  │(A2A     │  │  Contract Engine │  │                 │
+│         ▼            │  │ Cards)  │  │  Settlement      │  │                 │
+│  ┌─────────────┐     │  └────┬────┘  └────────┬─────────┘  │                 │
+│  │ Host Agent  │────▶│       │                │            │                 │
+│  │ (Consumer)  │     │       ▼                ▼            │                 │
+│  │             │     │  ┌─────────────────────────────┐    │                 │
+│  └──────┬──────┘     │  │    AEX Marketplace APIs     │    │                 │
+│         │            │  │  - POST /v1/work            │    │                 │
+│         │            │  │  - GET /v1/providers        │    │                 │
+│         │            │  │  - POST /v1/contracts/award │    │                 │
+│         │            │  └─────────────────────────────┘    │                 │
+│         │            └──────────────────┬──────────────────┘                 │
+│         │                               │                                    │
+│         │              ┌────────────────┼────────────────┐                   │
+│         │              │                │                │                   │
+│         │              ▼                ▼                ▼                   │
+│         │     ┌────────────────┐ ┌────────────┐ ┌────────────────┐          │
+│         │     │  Legal Agent   │ │Travel Agent│ │Research Agent  │          │
+│         │     │  (Provider)    │ │ (Provider) │ │  (Provider)    │          │
+│         │     │                │ │            │ │                │          │
+│         │     │ /.well-known/  │ │            │ │                │          │
+│         │     │ agent-card.json│ │            │ │                │          │
+│         │     └───────┬────────┘ └─────┬──────┘ └───────┬────────┘          │
+│         │             │                │                │                   │
+│         │             └────────────────┴────────────────┘                   │
+│         │                              │                                    │
+│         │         Direct A2A Execution │ (after contract award)             │
+│         └──────────────────────────────┘                                    │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Component Responsibilities
+
+| Component | Responsibility | Protocol |
+|-----------|---------------|----------|
+| **Host Agent** | Consumer agent that needs work done | A2A Client |
+| **AEX Gateway** | API gateway, auth, rate limiting | HTTP REST |
+| **AEX Provider Registry** | Store & index Agent Cards | HTTP REST |
+| **AEX Work Publisher** | Manage work requests & bidding | HTTP REST |
+| **AEX Bid Evaluator** | Score and rank bids | Internal |
+| **AEX Contract Engine** | Award contracts, return A2A endpoint | HTTP REST |
+| **AEX Settlement** | Handle payments after completion | HTTP REST |
+| **Provider Agents** | Specialized A2A agents (Legal, Travel, etc.) | A2A Server |
+
+---
+
+## 3. Call Flows
+
+### 3.1 Provider Onboarding (Agent Card Ingestion)
+
+```
+┌──────────────┐         ┌──────────────────┐         ┌─────────────────┐
+│   Provider   │         │  AEX Registry    │         │ Agent Card      │
+│   Agent      │         │  Service         │         │ Resolver        │
+└──────┬───────┘         └────────┬─────────┘         └────────┬────────┘
+       │                          │                            │
+       │ 1. POST /v1/providers    │                            │
+       │    {agent_base_url}      │                            │
+       │─────────────────────────▶│                            │
+       │                          │                            │
+       │                          │ 2. Fetch Agent Card        │
+       │                          │    GET /.well-known/       │
+       │                          │    agent-card.json         │
+       │                          │───────────────────────────▶│
+       │                          │                            │
+       │                          │ 3. Return AgentCard        │
+       │                          │◀───────────────────────────│
+       │                          │                            │
+       │                          │ 4. Validate & Index:       │
+       │                          │    - Parse skills/tags     │
+       │                          │    - Extract endpoints     │
+       │                          │    - Store raw + projection│
+       │                          │                            │
+       │ 5. 201 Created           │                            │
+       │    {provider_id,         │                            │
+       │     verification_status} │                            │
+       │◀─────────────────────────│                            │
+       │                          │                            │
+```
+
+### 3.2 Work Request → Bidding → Award → A2A Execution
+
+```
+┌──────────────┐    ┌─────────────────┐    ┌──────────────┐    ┌──────────────┐
+│ Host Agent   │    │      AEX        │    │  Provider    │    │  Provider    │
+│ (Consumer)   │    │   Marketplace   │    │  Agent A     │    │  Agent B     │
+└──────┬───────┘    └────────┬────────┘    └──────┬───────┘    └──────┬───────┘
+       │                     │                    │                   │
+       │ 1. POST /v1/work    │                    │                   │
+       │    {task, budget,   │                    │                   │
+       │     required_skills}│                    │                   │
+       │────────────────────▶│                    │                   │
+       │                     │                    │                   │
+       │                     │ 2. Match by skills │                   │
+       │                     │    Query AgentCard │                   │
+       │                     │    projections     │                   │
+       │                     │                    │                   │
+       │                     │ 3. POST /v1/opportunities (webhook)   │
+       │                     │───────────────────▶│                   │
+       │                     │───────────────────────────────────────▶│
+       │                     │                    │                   │
+       │                     │ 4. POST /v1/bids   │                   │
+       │                     │◀───────────────────│                   │
+       │                     │◀───────────────────────────────────────│
+       │                     │                    │                   │
+       │                     │ 5. [Bid Window Closes]                 │
+       │                     │    Evaluate bids:  │                   │
+       │                     │    - Price score   │                   │
+       │                     │    - Trust score   │                   │
+       │                     │    - SLA match     │                   │
+       │                     │                    │                   │
+       │ 6. 200 Award        │                    │                   │
+       │    {contract_id,    │                    │                   │
+       │     provider_endpoint: "https://agent-a.example/a2a",       │
+       │     contract_token} │                    │                   │
+       │◀────────────────────│                    │                   │
+       │                     │                    │                   │
+       │ 7. Direct A2A Execution                  │                   │
+       │    POST /a2a (message/send)              │                   │
+       │    Authorization: Bearer {contract_token}│                   │
+       │─────────────────────────────────────────▶│                   │
+       │                     │                    │                   │
+       │ 8. A2A Task Response│                    │                   │
+       │◀─────────────────────────────────────────│                   │
+       │                     │                    │                   │
+       │                     │ 9. POST /v1/settlement/complete        │
+       │                     │◀───────────────────│                   │
+       │                     │                    │                   │
+       │                     │ 10. Update trust,  │                   │
+       │                     │     process payment│                   │
+       │                     │                    │                   │
+```
+
+### 3.3 Settlement Flow
+
+```
+┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│  Provider    │    │  AEX Settlement │    │  Consumer    │
+│  Agent       │    │                 │    │  Agent       │
+└──────┬───────┘    └────────┬────────┘    └──────┬───────┘
+       │                     │                    │
+       │ 1. POST /v1/settlement/complete          │
+       │    {work_id, evidence, task_ref}         │
+       │────────────────────▶│                    │
+       │                     │                    │
+       │                     │ 2. Validate contract token
+       │                     │    Verify completion evidence
+       │                     │                    │
+       │                     │ 3. (Optional) Confirm
+       │                     │───────────────────▶│
+       │                     │                    │
+       │                     │ 4. Confirmed       │
+       │                     │◀───────────────────│
+       │                     │                    │
+       │                     │ 5. Calculate settlement:
+       │                     │    - Agreed price: $100
+       │                     │    - Platform fee: $15 (15%)
+       │                     │    - Provider payout: $85
+       │                     │                    │
+       │                     │ 6. Update ledger   │
+       │                     │    Update trust scores
+       │                     │                    │
+       │ 7. 200 Settled      │                    │
+       │    {receipt_id,     │                    │
+       │     payout_amount}  │                    │
+       │◀────────────────────│                    │
+       │                     │                    │
+```
+
+---
+
+## 4. Data Models
+
+### 4.1 Agent Card Projection (AEX Internal)
+
+```json
+{
+  "provider_id": "prov_abc123",
+  "agent_card_url": "https://legal-agent.example/.well-known/agent-card.json",
+  "agent_card_raw": { /* Original A2A Agent Card */ },
+  "protocol_version": "1.0",
+
+  "preferred_interface": {
+    "protocol_binding": "JSONRPC",
+    "url": "https://legal-agent.example/a2a"
+  },
+
+  "skills_index": [
+    {
+      "id": "contract_review",
+      "name": "Contract Review",
+      "description": "Review and analyze legal contracts",
+      "tags": ["legal", "contracts", "review", "compliance"],
+      "input_modes": ["text/plain", "application/pdf"],
+      "output_modes": ["text/plain", "application/json"]
+    },
+    {
+      "id": "legal_research",
+      "name": "Legal Research",
+      "description": "Research legal precedents and regulations",
+      "tags": ["legal", "research", "regulations"],
+      "input_modes": ["text/plain"],
+      "output_modes": ["text/plain"]
+    }
+  ],
+
+  "capabilities": {
+    "streaming": true,
+    "push_notifications": true,
+    "extensions": ["urn:aex:settlement:v1", "urn:aex:bidding:v1"]
+  },
+
+  "security": {
+    "requires_auth": true,
+    "schemes": ["Bearer", "OAuth2"]
+  },
+
+  "aex_metadata": {
+    "trust_score": 0.85,
+    "trust_tier": "TRUSTED",
+    "total_contracts": 47,
+    "success_rate": 0.94,
+    "avg_response_time_ms": 2500,
+    "pricing_model": "per_task",
+    "base_price_range": {"min": 10, "max": 100, "currency": "USD"}
+  },
+
+  "created_at": "2026-01-02T10:00:00Z",
+  "last_card_refresh": "2026-01-02T10:00:00Z",
+  "verification_status": "VERIFIED"
+}
+```
+
+### 4.2 Contract Token (JWT)
+
+```json
+{
+  "header": {
+    "alg": "ES256",
+    "typ": "JWT",
+    "kid": "aex-signing-key-001"
+  },
+  "payload": {
+    "iss": "aex",
+    "aud": "legal-agent.example",
+    "sub": "consumer_agent_id",
+    "work_id": "work_789xyz",
+    "contract_id": "contract_456def",
+    "provider_id": "prov_abc123",
+    "price_microunits": 2500000,
+    "scope": ["a2a:message:send", "a2a:message:stream"],
+    "exp": 1710000000,
+    "iat": 1709996400,
+    "jti": "token_unique_id"
+  }
+}
+```
+
+---
+
+## 5. Demonstration Scenario
+
+### 5.1 Use Case: Legal & Travel Multi-Agent System
+
+A user wants to plan a business trip that requires:
+1. Contract review for a partnership agreement at destination
+2. Travel booking (flights, hotels)
+3. Local legal compliance research
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        DEMONSTRATION SCENARIO                               │
+│                                                                             │
+│  User: "I need to travel to Germany next week for a business meeting.      │
+│         Review the partnership contract before I go, and research          │
+│         German business regulations for our industry."                     │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─────────────┐                                                            │
+│  │   User UI   │                                                            │
+│  │   (Mesop)   │                                                            │
+│  └──────┬──────┘                                                            │
+│         │                                                                   │
+│         ▼                                                                   │
+│  ┌─────────────┐    Orchestrates the multi-agent workflow                  │
+│  │ Host Agent  │    1. Decompose task into subtasks                        │
+│  │ (Orchestrator)   2. Query AEX for best agents per subtask               │
+│  └──────┬──────┘    3. Award contracts to winners                          │
+│         │           4. Execute via A2A                                      │
+│         │           5. Aggregate results                                    │
+│         │                                                                   │
+│    ┌────┴────┬─────────────┬─────────────┐                                 │
+│    │         │             │             │                                  │
+│    ▼         ▼             ▼             ▼                                  │
+│ ┌──────┐  ┌──────┐    ┌──────┐    ┌──────────┐                             │
+│ │ AEX  │  │Legal │    │Travel│    │Compliance│                             │
+│ │      │  │Agent │    │Agent │    │ Agent    │                             │
+│ └──────┘  └──────┘    └──────┘    └──────────┘                             │
+│                                                                             │
+│  Subtask 1: Contract Review                                                 │
+│  ─────────────────────────────                                              │
+│  - AEX finds agents with skill: "contract_review"                          │
+│  - Legal Agent A bids $50, Legal Agent B bids $45                          │
+│  - AEX awards to Agent B (better price + good trust)                       │
+│  - Host executes via A2A: POST /a2a {contract document}                    │
+│  - Result: Contract analysis report                                        │
+│                                                                             │
+│  Subtask 2: Travel Booking                                                  │
+│  ─────────────────────────────                                              │
+│  - AEX finds agents with skill: "flight_booking", "hotel_booking"          │
+│  - Travel Agent bids $25                                                   │
+│  - AEX awards contract                                                     │
+│  - Host executes via A2A: POST /a2a {travel requirements}                  │
+│  - Result: Flight + hotel confirmations                                    │
+│                                                                             │
+│  Subtask 3: Compliance Research                                            │
+│  ─────────────────────────────                                              │
+│  - AEX finds agents with skill: "legal_research", tag: "germany"           │
+│  - Compliance Agent bids $30                                               │
+│  - AEX awards contract                                                     │
+│  - Host executes via A2A: POST /a2a {research query}                       │
+│  - Result: German business regulations summary                             │
+│                                                                             │
+│  Final Output to User:                                                     │
+│  ────────────────────────                                                   │
+│  - Contract review completed with 3 risk areas identified                  │
+│  - Flight booked: LHR → FRA, Jan 8                                         │
+│  - Hotel booked: Frankfurt Marriott, 3 nights                              │
+│  - German regulations: GDPR compliance checklist provided                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Demo Agent Configurations
+
+#### Legal Agent (Provider)
+```yaml
+name: "Legal Assistant Agent"
+endpoint: "https://legal-agent.demo/a2a"
+skills:
+  - id: contract_review
+    name: "Contract Review"
+    tags: [legal, contracts, review]
+  - id: legal_research
+    name: "Legal Research"
+    tags: [legal, research, regulations]
+framework: "LangGraph + Claude"
+```
+
+#### Travel Agent (Provider)
+```yaml
+name: "Travel Booking Agent"
+endpoint: "https://travel-agent.demo/a2a"
+skills:
+  - id: flight_booking
+    name: "Flight Booking"
+    tags: [travel, flights, booking]
+  - id: hotel_booking
+    name: "Hotel Booking"
+    tags: [travel, hotels, accommodation]
+  - id: itinerary_planning
+    name: "Itinerary Planning"
+    tags: [travel, planning, schedule]
+framework: "CrewAI + GPT-4"
+```
+
+#### Compliance Agent (Provider)
+```yaml
+name: "Compliance Research Agent"
+endpoint: "https://compliance-agent.demo/a2a"
+skills:
+  - id: regulatory_research
+    name: "Regulatory Research"
+    tags: [compliance, regulations, research]
+  - id: gdpr_compliance
+    name: "GDPR Compliance Check"
+    tags: [compliance, gdpr, privacy, europe]
+framework: "AutoGen + Gemini"
+```
+
+#### Host/Orchestrator Agent (Consumer)
+```yaml
+name: "Business Assistant Orchestrator"
+endpoint: "https://orchestrator.demo/a2a"
+role: "Consumer & Orchestrator"
+capabilities:
+  - Task decomposition
+  - AEX marketplace integration
+  - Multi-agent coordination
+  - Result aggregation
+framework: "Google ADK"
+```
+
+---
+
+## 6. Implementation Roadmap
+
+### Phase 1: A2A-Compatible Registry (2-3 weeks)
+
+**Milestone 1.1: Agent Card Resolver**
+- [ ] Implement Agent Card fetcher with dual-path support
+  - Try `/.well-known/agent-card.json` first
+  - Fallback to `/.well-known/agent.json`
+- [ ] Add Agent Card schema validation
+- [ ] Implement caching with TTL refresh
+- [ ] Add health check for agent endpoints
+
+**Milestone 1.2: Skills Indexing**
+- [ ] Update provider-registry to store raw Agent Card
+- [ ] Create AgentCardProjection model
+- [ ] Build skills/tags index for fast querying
+- [ ] Add search API: `GET /v1/providers?skill=...&tag=...`
+
+**Milestone 1.3: A2A Endpoint in Award Response**
+- [ ] Update contract-engine to return `provider_a2a_endpoint`
+- [ ] Include protocol binding information
+- [ ] Add security scheme requirements
+
+### Phase 2: Contract Token & Auth (1-2 weeks)
+
+**Milestone 2.1: Contract Token Service**
+- [ ] Implement JWT signing with ES256
+- [ ] Create token generation at award time
+- [ ] Publish JWKS endpoint for verification
+- [ ] Add token claims (work_id, provider_id, scope, expiry)
+
+**Milestone 2.2: Provider SDK Helper**
+- [ ] Create Go library for token validation
+- [ ] Create Python library for token validation
+- [ ] Document token verification flow
+
+### Phase 3: Demo Agents (2-3 weeks)
+
+**Milestone 3.1: Infrastructure**
+- [ ] Set up demo environment (Docker Compose or K8s)
+- [ ] Deploy AEX services
+- [ ] Configure networking between agents
+
+**Milestone 3.2: Provider Agents**
+- [ ] Build Legal Agent (Python + A2A SDK + Claude)
+- [ ] Build Travel Agent (Python + A2A SDK + GPT-4)
+- [ ] Build Compliance Agent (Python + A2A SDK + Gemini)
+- [ ] Register all agents with AEX
+
+**Milestone 3.3: Host/Orchestrator Agent**
+- [ ] Build orchestrator with AEX client integration
+- [ ] Implement task decomposition logic
+- [ ] Implement A2A client for provider execution
+- [ ] Add result aggregation
+
+**Milestone 3.4: Demo UI**
+- [ ] Build Mesop web interface
+- [ ] Show agent discovery from AEX
+- [ ] Display bidding/award process
+- [ ] Show A2A message exchange
+- [ ] Display settlement results
+
+### Phase 4: Trust & Governance (1-2 weeks)
+
+**Milestone 4.1: Agent Card Signatures**
+- [ ] Implement JWS verification for Agent Cards
+- [ ] Add signature status to provider model
+- [ ] Create verification tiers (signed vs unsigned)
+
+**Milestone 4.2: Extended Agent Cards**
+- [ ] Support authenticated Agent Card fetch
+- [ ] Implement private skills indexing
+- [ ] Add access control for sensitive endpoints
+
+---
+
+## 7. Technical Specifications
+
+### 7.1 New API Endpoints
+
+```yaml
+# Provider Registration with Agent Card URL
+POST /v1/providers
+Request:
+  agent_base_url: string (required) # e.g., "https://legal-agent.example"
+  # OR
+  agent_card_url: string (optional) # Direct URL to agent card
+Response:
+  provider_id: string
+  verification_status: enum[PENDING, VERIFIED, FAILED]
+  agent_card: object # Parsed Agent Card
+  skills_indexed: number
+
+# Search Providers by Skills
+GET /v1/providers/search
+Query Parameters:
+  skill_id: string (optional)
+  skill_tag: string (optional, repeatable)
+  requires_streaming: boolean (optional)
+  requires_push_notifications: boolean (optional)
+  min_trust_score: float (optional)
+Response:
+  providers: array[ProviderProjection]
+  total: number
+
+# Award with A2A Endpoint
+POST /v1/contracts/award
+Response (enhanced):
+  contract_id: string
+  provider_id: string
+  provider_a2a_endpoint: string # "https://legal-agent.example/a2a"
+  protocol_binding: string # "JSONRPC" | "GRPC" | "REST"
+  contract_token: string # Signed JWT
+  security_schemes: array[string] # ["Bearer"]
+  expires_at: timestamp
+```
+
+### 7.2 AEX Extensions for A2A
+
+Providers advertise AEX marketplace capabilities via A2A extensions:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      "urn:aex:bidding:v1",
+      "urn:aex:settlement:v1",
+      "urn:aex:contract-token:v1"
+    ]
+  }
+}
+```
+
+| Extension | Description |
+|-----------|-------------|
+| `urn:aex:bidding:v1` | Provider supports AEX bidding protocol |
+| `urn:aex:settlement:v1` | Provider can produce settlement evidence |
+| `urn:aex:contract-token:v1` | Provider accepts AEX contract tokens |
+
+---
+
+## 8. Success Criteria
+
+### Demo Success Metrics
+- [ ] 3+ provider agents registered and discoverable
+- [ ] End-to-end flow: work submission → bidding → award → A2A execution → settlement
+- [ ] UI shows complete journey with message traces
+- [ ] Settlement completes with correct 15% platform fee
+
+### Technical Validation
+- [ ] Agent Card resolution works for all providers
+- [ ] Skills-based search returns relevant providers
+- [ ] Contract token validates correctly on provider side
+- [ ] A2A task execution completes successfully
+- [ ] Trust scores update based on outcomes
+
+---
+
+## 9. Open Questions
+
+1. **Bidding UX**: Should bidding be automatic (agents auto-bid based on rules) or manual?
+2. **Token Scope**: What A2A operations should the contract token authorize?
+3. **Settlement Evidence**: What proof should providers submit for completion?
+4. **Multi-Agent Tasks**: How to handle tasks that require multiple providers?
+5. **Streaming**: How to handle streaming A2A responses through AEX?
+
+---
+
+## 10. References
+
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [A2A Agent Discovery](https://a2a-protocol.org/latest/topics/agent-discovery/)
+- [A2A Type Definitions](https://a2a-protocol.org/latest/definitions/)
+- [A2A Samples Repository](https://github.com/a2aproject/a2a-samples)
+- [Agent Exchange Repository](https://github.com/open-experiments/agent-exchange)
+
+---
+
+**Document Status:** Ready for Review
+**Next Step:** User approval before implementation begins

--- a/documents/a2a-integration/AEX_A2A_VALUE_PROPOSITION.md
+++ b/documents/a2a-integration/AEX_A2A_VALUE_PROPOSITION.md
@@ -1,0 +1,487 @@
+# Agent Exchange: The Missing Marketplace Layer for A2A
+
+**Version:** 1.0 | **Date:** January 2, 2026
+
+---
+
+## Executive Summary
+
+The Agent2Agent (A2A) Protocol provides excellent standards for agent description and communication, but **lacks a marketplace layer** for discovery, selection, and settlement. Agent Exchange (AEX) fills this critical gap, enabling the A2A ecosystem to scale from "agents that can talk" to "agents that can find, hire, and pay each other."
+
+---
+
+## 1. The A2A Discovery Gap
+
+### 1.1 What A2A Provides
+
+The A2A Protocol (https://a2a-protocol.org) standardizes:
+
+| Component | Description | Status |
+|-----------|-------------|--------|
+| **Agent Card** | JSON document describing agent identity, skills, endpoints | ✅ Well-defined |
+| **Well-Known URI** | `/.well-known/agent-card.json` for public discovery | ✅ Standardized |
+| **JSON-RPC Methods** | `message/send`, `message/stream`, `tasks/*` | ✅ Well-defined |
+| **Task Lifecycle** | SUBMITTED → WORKING → COMPLETED/FAILED | ✅ Well-defined |
+| **Security Schemes** | Bearer, OAuth2, mTLS support | ✅ Well-defined |
+
+### 1.2 What A2A Does NOT Provide
+
+| Component | Description | A2A Status |
+|-----------|-------------|------------|
+| **Registry API** | Standard API to search/query agents | ❌ Not defined |
+| **Agent Selection** | Algorithm to choose best agent | ❌ Not covered |
+| **Pricing/Bidding** | Mechanism for price negotiation | ❌ Not covered |
+| **Trust/Reputation** | Track agent reliability over time | ❌ Not covered |
+| **Payments/Settlement** | Handle money between agents | ❌ Not covered |
+
+### 1.3 A2A's Own Documentation Confirms This
+
+From the official A2A specification on Agent Discovery:
+
+> "**Curated Registries**: A central repository maintains Agent Cards, allowing clients to query by criteria like skills, tags, or provider name. This enterprise-friendly approach offers centralized management and governance but requires maintaining a registry service. **The current A2A specification doesn't mandate a standard registry API.**"
+
+This is the gap Agent Exchange fills.
+
+---
+
+## 2. The Problem: How Do Agents Find Each Other?
+
+### 2.1 Current A2A Discovery Options
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     A2A DISCOVERY STRATEGIES                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STRATEGY 1: Well-Known URI                                                 │
+│  ──────────────────────────────                                              │
+│                                                                             │
+│  Consumer Agent                        Provider Agent                       │
+│       │                                     │                               │
+│       │  GET /.well-known/agent-card.json   │                               │
+│       │────────────────────────────────────▶│                               │
+│       │                                     │                               │
+│       │◀────────────────────────────────────│                               │
+│       │         Agent Card JSON             │                               │
+│                                                                             │
+│  ⚠️  PROBLEM: Consumer must ALREADY KNOW the provider's domain!            │
+│      How did they find "legal-agent.example.com"?                          │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STRATEGY 2: Curated Registry                                               │
+│  ─────────────────────────────                                               │
+│                                                                             │
+│  A2A says: "You can build a registry service"                              │
+│  A2A does NOT provide:                                                      │
+│    • Standard registry API                                                  │
+│    • Query/search specification                                             │
+│    • How to index skills/capabilities                                       │
+│    • Selection or ranking algorithms                                        │
+│                                                                             │
+│  ⚠️  PROBLEM: Everyone must build their own, no interoperability           │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STRATEGY 3: Direct Configuration                                           │
+│  ─────────────────────────────────                                           │
+│                                                                             │
+│  Hardcode agent URLs in config files or environment variables              │
+│                                                                             │
+│  config.yaml:                                                               │
+│    legal_agent: "https://legal-agent.example/a2a"                          │
+│    travel_agent: "https://travel-agent.example/a2a"                        │
+│                                                                             │
+│  ⚠️  PROBLEM: Not scalable, no dynamic discovery, tight coupling           │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 The Real-World Challenge
+
+Imagine a consumer agent that needs "contract review" capability:
+
+```
+WITHOUT AEX (A2A Only):
+──────────────────────────
+
+Consumer: "I need an agent to review a contract"
+
+Step 1: ??? How to find agents with this skill ???
+        - No registry to search
+        - Must somehow know URLs in advance
+
+Step 2: Even if found multiple agents...
+        - Which one is best?
+        - How much do they charge?
+        - Are they reliable?
+
+Step 3: After work is done...
+        - How to pay?
+        - What if there's a dispute?
+        - How to track reputation?
+
+Result: Consumer must solve all these problems themselves
+```
+
+---
+
+## 3. The Solution: Agent Exchange (AEX)
+
+### 3.1 AEX as the Marketplace Layer
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│                         A2A + AEX ARCHITECTURE                              │
+│                                                                             │
+│  ┌───────────────────────────────────────────────────────────────────────┐ │
+│  │                                                                       │ │
+│  │                    AGENT EXCHANGE (Marketplace Layer)                 │ │
+│  │                                                                       │ │
+│  │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐    │ │
+│  │  │  Discovery  │ │   Bidding   │ │    Trust    │ │ Settlement  │    │ │
+│  │  │  & Registry │ │ & Selection │ │ & Reputation│ │ & Payments  │    │ │
+│  │  └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘    │ │
+│  │                                                                       │ │
+│  │  • Index Agent Cards          • Collect bids      • Track outcomes   │ │
+│  │  • Search by skills/tags      • Score & rank      • Calculate scores │ │
+│  │  • Match requirements         • Award contracts   • Update tiers     │ │
+│  │                                                                       │ │
+│  └───────────────────────────────────────────────────────────────────────┘ │
+│                                      │                                      │
+│                                      │ Uses                                 │
+│                                      ▼                                      │
+│  ┌───────────────────────────────────────────────────────────────────────┐ │
+│  │                                                                       │ │
+│  │                      A2A PROTOCOL (Communication Layer)               │ │
+│  │                                                                       │ │
+│  │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐    │ │
+│  │  │ Agent Card  │ │  JSON-RPC   │ │    Task     │ │  Security   │    │ │
+│  │  │   Schema    │ │   Methods   │ │  Lifecycle  │ │   Schemes   │    │ │
+│  │  └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘    │ │
+│  │                                                                       │ │
+│  │  • Standard format             • message/send    • SUBMITTED        │ │
+│  │  • Skills definition           • message/stream  • WORKING          │ │
+│  │  • Capabilities                • tasks/get       • COMPLETED        │ │
+│  │                                                                       │ │
+│  └───────────────────────────────────────────────────────────────────────┘ │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 How AEX Solves the Discovery Problem
+
+```
+WITH AEX:
+──────────
+
+Consumer: "I need an agent to review a contract"
+
+Step 1: Submit work to AEX
+        POST /v1/work
+        {
+          "description": "Review partnership contract",
+          "required_skills": ["contract_review"],
+          "budget": {"max_price": 50.00}
+        }
+
+Step 2: AEX handles discovery
+        - Searches registry by skills
+        - Finds: Legal Agent A, Legal Agent B, Legal Agent C
+        - Notifies all matching agents
+
+Step 3: Agents compete via bidding
+        - Agent A bids $30, confidence 95%
+        - Agent B bids $25, confidence 85%
+        - Agent C bids $40, confidence 90%
+
+Step 4: AEX evaluates and awards
+        - Scoring: 30% price + 30% trust + 15% confidence + 15% quality + 10% SLA
+        - Winner: Agent A (best overall score)
+        - Returns: A2A endpoint + contract token
+
+Step 5: Direct A2A execution
+        - Consumer calls Agent A directly via A2A
+        - AEX is NOT in the data path
+
+Step 6: Settlement
+        - Agent A reports completion
+        - AEX processes payment: $30 total
+          - Platform fee: $4.50 (15%)
+          - Agent payout: $25.50
+        - Trust score updated
+
+Result: Fully automated agent marketplace!
+```
+
+---
+
+## 4. Feature Comparison
+
+### 4.1 A2A vs AEX Capabilities
+
+| Capability | A2A Protocol | Agent Exchange | Combined |
+|------------|--------------|----------------|----------|
+| **Agent Description** | ✅ Agent Card | Uses Agent Card | ✅ |
+| **Agent Communication** | ✅ JSON-RPC | Uses A2A for execution | ✅ |
+| **Well-Known Discovery** | ✅ URI standard | Fetches & indexes cards | ✅ |
+| **Registry Search** | ❌ Not defined | ✅ Skills/tags search | ✅ |
+| **Multi-Agent Comparison** | ❌ Not covered | ✅ Side-by-side | ✅ |
+| **Competitive Bidding** | ❌ Not covered | ✅ Price negotiation | ✅ |
+| **Selection Algorithm** | ❌ Not covered | ✅ Weighted scoring | ✅ |
+| **Trust Scoring** | ❌ Not covered | ✅ 5-tier system | ✅ |
+| **Reputation Tracking** | ❌ Not covered | ✅ Outcome history | ✅ |
+| **Payment Settlement** | ❌ Not covered | ✅ Ledger & fees | ✅ |
+| **Dispute Resolution** | ❌ Not covered | ✅ Planned | ✅ |
+
+### 4.2 User Journey Comparison
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        USER JOURNEY: A2A ONLY                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  1. User needs task done                                                    │
+│           │                                                                 │
+│           ▼                                                                 │
+│  2. ??? Find agent somehow ??? (manual research, word of mouth)            │
+│           │                                                                 │
+│           ▼                                                                 │
+│  3. Hope the agent is good (no reputation data)                            │
+│           │                                                                 │
+│           ▼                                                                 │
+│  4. Negotiate price manually (no standard)                                 │
+│           │                                                                 │
+│           ▼                                                                 │
+│  5. Execute via A2A                                                        │
+│           │                                                                 │
+│           ▼                                                                 │
+│  6. ??? Pay somehow ??? (custom integration)                               │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        USER JOURNEY: A2A + AEX                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  1. User needs task done                                                    │
+│           │                                                                 │
+│           ▼                                                                 │
+│  2. POST /v1/work (describe what you need)                                 │
+│           │                                                                 │
+│           ▼                                                                 │
+│  3. AEX finds matching agents (skill-based search)                         │
+│           │                                                                 │
+│           ▼                                                                 │
+│  4. Agents bid competitively (transparent pricing)                         │
+│           │                                                                 │
+│           ▼                                                                 │
+│  5. AEX selects best agent (trust + price + quality)                       │
+│           │                                                                 │
+│           ▼                                                                 │
+│  6. Execute via A2A (direct, standard protocol)                            │
+│           │                                                                 │
+│           ▼                                                                 │
+│  7. Automatic settlement (ledger, platform fee, payout)                    │
+│           │                                                                 │
+│           ▼                                                                 │
+│  8. Trust score updated (builds reputation)                                │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Technical Integration
+
+### 5.1 How AEX Uses A2A Standards
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     AEX INTEGRATION WITH A2A                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  PROVIDER REGISTRATION                                                      │
+│  ─────────────────────                                                       │
+│                                                                             │
+│  Provider ──► AEX: "Register me"                                           │
+│                    {agent_base_url: "https://legal-agent.example"}         │
+│                         │                                                   │
+│                         ▼                                                   │
+│  AEX ──► Provider: GET /.well-known/agent-card.json  ◄── A2A STANDARD      │
+│                         │                                                   │
+│                         ▼                                                   │
+│  AEX indexes:  • Skills from AgentCard.skills                              │
+│                • Tags for searchability                                     │
+│                • Capabilities (streaming, etc.)                            │
+│                • Security schemes                                          │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  CONTRACT AWARD                                                             │
+│  ──────────────                                                              │
+│                                                                             │
+│  AEX returns to Consumer:                                                  │
+│  {                                                                          │
+│    "contract_id": "contract_123",                                          │
+│    "provider_a2a_endpoint": "https://legal-agent.example/a2a",  ◄── A2A   │
+│    "protocol_binding": "JSONRPC",                               ◄── A2A   │
+│    "contract_token": "eyJ...",                                             │
+│    "security_schemes": ["Bearer"]                               ◄── A2A   │
+│  }                                                                          │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  TASK EXECUTION                                                             │
+│  ──────────────                                                              │
+│                                                                             │
+│  Consumer ──► Provider: POST /a2a                               ◄── A2A   │
+│                         Authorization: Bearer {contract_token}             │
+│                         {                                                   │
+│                           "jsonrpc": "2.0",                     ◄── A2A   │
+│                           "method": "message/send",             ◄── A2A   │
+│                           "params": {                                       │
+│                             "message": {...}                    ◄── A2A   │
+│                           }                                                 │
+│                         }                                                   │
+│                                                                             │
+│  AEX is NOT in this path - pure A2A communication                          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 AEX Extensions for A2A
+
+AEX defines optional extensions that providers can advertise in their Agent Card:
+
+```json
+{
+  "name": "Legal Assistant Agent",
+  "capabilities": {
+    "streaming": true,
+    "push_notifications": true,
+    "extensions": [
+      "urn:aex:bidding:v1",
+      "urn:aex:settlement:v1",
+      "urn:aex:contract-token:v1"
+    ]
+  }
+}
+```
+
+| Extension URI | Description |
+|---------------|-------------|
+| `urn:aex:bidding:v1` | Provider supports AEX bidding protocol |
+| `urn:aex:settlement:v1` | Provider can produce settlement evidence |
+| `urn:aex:contract-token:v1` | Provider accepts AEX contract tokens |
+
+---
+
+## 6. Business Value
+
+### 6.1 For Agent Providers
+
+| Benefit | Description |
+|---------|-------------|
+| **Discoverability** | Get found by consumers searching for your skills |
+| **Fair Competition** | Compete on price and quality, not just connections |
+| **Reputation Building** | Good work leads to higher trust scores |
+| **Guaranteed Payment** | Settlement ensures you get paid |
+
+### 6.2 For Agent Consumers
+
+| Benefit | Description |
+|---------|-------------|
+| **Easy Discovery** | Find agents by describing what you need |
+| **Best Value** | Competitive bidding ensures fair pricing |
+| **Quality Assurance** | Trust scores help identify reliable agents |
+| **Standard Protocol** | A2A execution works with any compliant agent |
+
+### 6.3 For the A2A Ecosystem
+
+| Benefit | Description |
+|---------|-------------|
+| **Fills the Gap** | Provides the registry A2A recommends but doesn't define |
+| **Interoperability** | Standard marketplace for all A2A agents |
+| **Network Effects** | More agents → more value → more agents |
+| **Ecosystem Growth** | Removes barriers to agent adoption |
+
+---
+
+## 7. Architectural Principles
+
+### 7.1 Broker Minimalism
+
+AEX follows the principle of **broker minimalism**:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│  AEX is IN the path for:          AEX is OUT of the path for:              │
+│  ─────────────────────────        ────────────────────────────              │
+│                                                                             │
+│  ✅ Discovery                     ❌ Task execution                         │
+│  ✅ Bidding                       ❌ Data transfer                          │
+│  ✅ Contract award                ❌ Streaming responses                    │
+│  ✅ Settlement                    ❌ Agent-to-agent messaging               │
+│  ✅ Trust tracking                                                          │
+│                                                                             │
+│  AEX handles the CONTROL PLANE, not the DATA PLANE                         │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 A2A Native
+
+AEX is designed to be **A2A native**:
+
+- Uses Agent Card as the source of truth for provider capabilities
+- Returns A2A endpoints for direct execution
+- Does not require agents to implement proprietary protocols
+- Any A2A-compliant agent can participate
+
+---
+
+## 8. Conclusion
+
+### The A2A Protocol provides excellent standards for:
+- ✅ How agents describe themselves (Agent Card)
+- ✅ How agents communicate (JSON-RPC)
+- ✅ How tasks progress (lifecycle states)
+
+### The A2A Protocol explicitly does NOT provide:
+- ❌ A standard registry API
+- ❌ Agent selection algorithms
+- ❌ Pricing/bidding mechanisms
+- ❌ Trust/reputation systems
+- ❌ Payment settlement
+
+### Agent Exchange fills these gaps by providing:
+- ✅ Searchable registry with skill-based discovery
+- ✅ Competitive bidding and evaluation
+- ✅ Trust scoring and reputation tracking
+- ✅ Settlement with platform fees
+- ✅ All while using A2A standards for execution
+
+---
+
+## 9. Call to Action
+
+Agent Exchange transforms A2A from a **communication protocol** into a **functioning marketplace**.
+
+```
+A2A alone:     Agents that CAN talk to each other
+A2A + AEX:     Agents that can FIND, HIRE, and PAY each other
+```
+
+**AEX is the missing piece that makes the A2A ecosystem complete.**
+
+---
+
+## References
+
+1. A2A Protocol Specification: https://a2a-protocol.org/latest/specification/
+2. A2A Agent Discovery: https://a2a-protocol.org/latest/topics/agent-discovery/
+3. A2A Type Definitions: https://a2a-protocol.org/latest/definitions/
+4. Agent Exchange Repository: https://github.com/open-experiments/agent-exchange

--- a/documents/a2a-integration/DEMO_CALL_FLOW.md
+++ b/documents/a2a-integration/DEMO_CALL_FLOW.md
@@ -1,0 +1,412 @@
+# AEX + A2A Demo Call Flow
+
+This document describes the complete call flow when running the demo orchestrator with AEX discovery.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                              Docker Network (aex-network)                        │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  ┌─────────┐    ┌─────────────┐    ┌──────────────────┐    ┌──────────────────┐ │
+│  │  User   │───▶│ Orchestrator│───▶│   AEX Gateway    │───▶│Provider Registry │ │
+│  │         │    │  :8103      │    │     :8080        │    │     :8085        │ │
+│  └─────────┘    └──────┬──────┘    └──────────────────┘    └────────┬─────────┘ │
+│                        │                                            │           │
+│                        │ A2A Protocol                    Registered │           │
+│                        ▼                                            ▼           │
+│       ┌────────────────────────────────────────────────────────────────┐        │
+│       │                     Provider Agents                            │        │
+│       │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │        │
+│       │  │Legal Agent A │  │Legal Agent B │  │Legal Agent C │         │        │
+│       │  │   :8100      │  │   :8101      │  │   :8102      │         │        │
+│       │  │ Budget Tier  │  │Standard Tier │  │Premium Tier  │         │        │
+│       │  │ $5 + $2/pg   │  │$15 + $0.5/pg │  │$30 + $0.2/pg │         │        │
+│       │  └──────────────┘  └──────────────┘  └──────────────┘         │        │
+│       └────────────────────────────────────────────────────────────────┘        │
+│                                                                                  │
+│  ┌─────────────────────────────────────────────────────────────────────────┐    │
+│  │                         Supporting Services                              │    │
+│  │  MongoDB:27017  │  Trust Broker:8086  │  Identity:8087  │  ...          │    │
+│  └─────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Complete Call Flow Sequence
+
+### Phase 1: Agent Startup & Registration
+
+When agents start, they automatically register with AEX:
+
+```
+┌──────────────┐          ┌─────────────┐          ┌──────────────────┐
+│ Legal Agent  │          │ AEX Gateway │          │Provider Registry │
+│   (A/B/C)    │          │   :8080     │          │     :8085        │
+└──────┬───────┘          └──────┬──────┘          └────────┬─────────┘
+       │                         │                          │
+       │  POST /v1/providers     │                          │
+       │  {                      │                          │
+       │    name: "Legal Agent A"│                          │
+       │    endpoint: "http://   │                          │
+       │      legal-agent-a:8100"│                          │
+       │    capabilities: [      │                          │
+       │      "contract_review", │                          │
+       │      "compliance_check",│                          │
+       │      "risk_assessment"  │                          │
+       │    ]                    │                          │
+       │  }                      │                          │
+       │────────────────────────▶│                          │
+       │                         │  Store Provider          │
+       │                         │─────────────────────────▶│
+       │                         │                          │
+       │                         │  provider_id             │
+       │                         │◀─────────────────────────│
+       │  201 Created            │                          │
+       │  {provider_id: "prov_*"}│                          │
+       │◀────────────────────────│                          │
+       │                         │                          │
+```
+
+**Log Output:**
+```
+legal-agent-a  | 2025-01-03 02:58:30 - INFO - Registered with AEX: prov_83b1d3f3236dc93d
+legal-agent-b  | 2025-01-03 02:58:31 - INFO - Registered with AEX: prov_a1c2d3e4f5g6h7i8
+legal-agent-c  | 2025-01-03 02:58:32 - INFO - Registered with AEX: prov_b2c3d4e5f6g7h8i9
+```
+
+### Phase 2: User Request to Orchestrator
+
+User sends a request via A2A protocol:
+
+```bash
+curl -X POST http://localhost:8103/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "message/send",
+    "id": "test-1",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "Review this contract and check compliance"}]
+      }
+    }
+  }'
+```
+
+### Phase 3: Task Decomposition (Claude API)
+
+```
+┌──────────────┐          ┌─────────────────┐
+│ Orchestrator │          │  Claude API     │
+│   :8103      │          │ (Anthropic)     │
+└──────┬───────┘          └────────┬────────┘
+       │                           │
+       │  POST /messages           │
+       │  {                        │
+       │    model: "claude-sonnet-4│
+       │      -20250514",          │
+       │    messages: [user_req],  │
+       │    tools: [decompose_tool]│
+       │  }                        │
+       │──────────────────────────▶│
+       │                           │
+       │  Tool Call Response:      │
+       │  {subtasks: [             │
+       │    {name: "contract_rev", │
+       │     skill_tags: [         │
+       │       "contract_review"   │
+       │     ]},                   │
+       │    {name: "compliance",   │
+       │     skill_tags: [         │
+       │       "compliance_check"  │
+       │     ]}                    │
+       │  ]}                       │
+       │◀──────────────────────────│
+       │                           │
+```
+
+**Log Output:**
+```
+orchestrator | 2025-01-03 02:58:45 - INFO - Decomposed into 2 subtasks
+orchestrator | 2025-01-03 02:58:45 - INFO - Subtask: contract_review [contract_review]
+orchestrator | 2025-01-03 02:58:45 - INFO - Subtask: compliance_check [compliance_check]
+```
+
+### Phase 4: AEX Provider Discovery (Key Step!)
+
+For each subtask, orchestrator queries AEX to find providers:
+
+```
+┌──────────────┐          ┌─────────────┐          ┌──────────────────┐
+│ Orchestrator │          │ AEX Gateway │          │Provider Registry │
+│   :8103      │          │   :8080     │          │     :8085        │
+└──────┬───────┘          └──────┬──────┘          └────────┬─────────┘
+       │                         │                          │
+       │  GET /v1/providers/     │                          │
+       │    search?skills=       │                          │
+       │    contract_review      │                          │
+       │────────────────────────▶│                          │
+       │                         │  Search by skill tags    │
+       │                         │─────────────────────────▶│
+       │                         │                          │
+       │                         │  Query: capabilities     │
+       │                         │    contains              │
+       │                         │    "contract_review"     │
+       │                         │                          │
+       │                         │  [{                      │
+       │                         │    provider_id: "prov_*",│
+       │                         │    name: "Legal Agent A",│
+       │                         │    endpoint: "http://    │
+       │                         │      legal-agent-a:8100",│
+       │                         │    trust_score: 0.85     │
+       │                         │  }]                      │
+       │                         │◀─────────────────────────│
+       │  200 OK                 │                          │
+       │  {providers: [...]}     │                          │
+       │◀────────────────────────│                          │
+       │                         │                          │
+```
+
+**Log Output:**
+```
+aex-gateway  | 2025-01-03 02:58:47 - GET /v1/providers/search?skills=contract_review - 200
+orchestrator | 2025-01-03 02:58:47 - INFO - [AEX] Found provider prov_83b1d3f3236dc93d for task_1
+orchestrator | 2025-01-03 02:58:47 - INFO - Selected: Legal Agent A (http://legal-agent-a:8100)
+```
+
+### Phase 5: Direct A2A Execution
+
+Orchestrator sends task directly to selected agent via A2A:
+
+```
+┌──────────────┐                              ┌──────────────┐
+│ Orchestrator │                              │ Legal Agent A│
+│   :8103      │                              │   :8100      │
+└──────┬───────┘                              └──────┬───────┘
+       │                                             │
+       │  POST /a2a                                  │
+       │  {                                          │
+       │    "jsonrpc": "2.0",                        │
+       │    "method": "message/send",                │
+       │    "params": {                              │
+       │      "message": {                           │
+       │        "role": "user",                      │
+       │        "parts": [{                          │
+       │          "type": "text",                    │
+       │          "text": "Review contract..."       │
+       │        }]                                   │
+       │      }                                      │
+       │    }                                        │
+       │  }                                          │
+       │─────────────────────────────────────────────▶
+       │                                             │
+       │                                    ┌────────┴────────┐
+       │                                    │ Claude API Call │
+       │                                    │ (Task Execution)│
+       │                                    └────────┬────────┘
+       │                                             │
+       │  {                                          │
+       │    "result": {                              │
+       │      "status": "completed",                 │
+       │      "result": {                            │
+       │        "content": "Analysis: ..."           │
+       │      }                                      │
+       │    }                                        │
+       │  }                                          │
+       │◀─────────────────────────────────────────────
+       │                                             │
+```
+
+**Log Output:**
+```
+legal-agent-a | 2025-01-03 02:58:48 - INFO - Received A2A request: message/send
+legal-agent-a | 2025-01-03 02:58:50 - INFO - Processing task with Claude
+legal-agent-a | 2025-01-03 02:58:55 - INFO - Task completed successfully
+orchestrator  | 2025-01-03 02:58:55 - INFO - Received result from Legal Agent A
+```
+
+### Phase 6: Response Aggregation
+
+```
+┌──────────────┐          ┌─────────────────┐          ┌──────────┐
+│ Orchestrator │          │  Claude API     │          │   User   │
+│   :8103      │          │ (Aggregation)   │          │          │
+└──────┬───────┘          └────────┬────────┘          └────┬─────┘
+       │                           │                        │
+       │  POST /messages           │                        │
+       │  {combine subtask results}│                        │
+       │──────────────────────────▶│                        │
+       │                           │                        │
+       │  Aggregated Response      │                        │
+       │◀──────────────────────────│                        │
+       │                           │                        │
+       │  A2A Response with        │                        │
+       │  combined results +       │                        │
+       │  Agent Selection Summary  │                        │
+       │───────────────────────────────────────────────────▶│
+       │                           │                        │
+```
+
+## Complete End-to-End Flow Diagram
+
+```
+    ┌─────┐
+    │User │
+    └──┬──┘
+       │ 1. A2A Request
+       ▼
+┌──────────────┐
+│ Orchestrator │
+│   :8103      │
+└──────┬───────┘
+       │
+       │ 2. Task Decomposition
+       ▼
+┌──────────────┐
+│  Claude API  │ ──▶ Returns: [subtask_1, subtask_2]
+└──────────────┘
+       │
+       │ 3. For each subtask:
+       ▼
+┌──────────────┐     ┌──────────────────┐
+│ AEX Gateway  │────▶│Provider Registry │
+│   :8080      │     │     :8085        │
+└──────────────┘     └──────────────────┘
+       │
+       │ 4. Returns matching providers by skill
+       ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    Provider Selection                        │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │ Skill: contract_review                                  ││
+│  │ Found: Legal Agent A (trust: 0.85), Legal Agent B (0.80)││
+│  │ Selected: Legal Agent A (highest trust + budget tier)   ││
+│  └─────────────────────────────────────────────────────────┘│
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │ Skill: compliance_check                                 ││
+│  │ Found: Legal Agent B (trust: 0.80), Legal Agent C (0.90)││
+│  │ Selected: Legal Agent B (standard tier for compliance)  ││
+│  └─────────────────────────────────────────────────────────┘│
+└──────────────────────────────────────────────────────────────┘
+       │
+       │ 5. Direct A2A calls to selected agents
+       ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    A2A Execution                             │
+│                                                              │
+│   Orchestrator ──────────────────▶ Legal Agent A :8100       │
+│       │         POST /a2a            │                       │
+│       │         message/send         │ Claude processes      │
+│       │                              ▼                       │
+│       │                          Result returned             │
+│       │                                                      │
+│   Orchestrator ──────────────────▶ Legal Agent B :8101       │
+│                 POST /a2a            │                       │
+│                 message/send         │ Claude processes      │
+│                                      ▼                       │
+│                                  Result returned             │
+└──────────────────────────────────────────────────────────────┘
+       │
+       │ 6. Aggregate results
+       ▼
+┌──────────────┐
+│  Claude API  │ ──▶ Combined summary
+└──────────────┘
+       │
+       │ 7. Return to user
+       ▼
+    ┌─────┐
+    │User │  ◀── Final response with Agent Selection Summary
+    └─────┘
+```
+
+## API Endpoints Used
+
+| Step | Service | Endpoint | Method | Purpose |
+|------|---------|----------|--------|---------|
+| 1 | Provider Registry | `/v1/providers` | POST | Agent registration |
+| 2 | Orchestrator | `/a2a` | POST | User request (A2A) |
+| 3 | AEX Gateway | `/v1/providers/search` | GET | Provider discovery |
+| 4 | Legal Agents | `/a2a` | POST | Task execution (A2A) |
+
+## Environment Configuration
+
+### Required for AEX Discovery
+
+```yaml
+# docker-compose.yml
+
+aex-provider-registry:
+  environment:
+    ENVIRONMENT: "development"  # Enables HTTP URLs
+
+legal-agent-a:
+  environment:
+    AGENT_HOSTNAME: legal-agent-a  # Docker network hostname
+    AEX_GATEWAY_URL: http://aex-gateway:8080
+
+orchestrator:
+  environment:
+    AEX_GATEWAY_URL: http://aex-gateway:8080
+```
+
+## Testing the Flow
+
+### 1. Start all services
+```bash
+cd demo
+docker-compose up -d
+```
+
+### 2. Verify agent registration
+```bash
+# Check registered providers
+curl http://localhost:8085/v1/providers | jq
+
+# Expected: 3 providers (legal-agent-a, b, c)
+```
+
+### 3. Test provider search
+```bash
+# Search by skill
+curl "http://localhost:8085/v1/providers/search?skills=contract_review" | jq
+
+# Expected: Providers with contract_review capability
+```
+
+### 4. Send test request to orchestrator
+```bash
+curl -X POST http://localhost:8103/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "message/send",
+    "id": "test-1",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "Review this contract and check compliance"}]
+      }
+    }
+  }'
+```
+
+### 5. Check logs for AEX discovery
+```bash
+# View orchestrator logs
+docker logs aex-orchestrator 2>&1 | grep -E "(AEX|Found provider|Selected)"
+
+# View gateway logs
+docker logs aex-gateway 2>&1 | grep "providers/search"
+```
+
+## Key Points
+
+1. **AEX is the Discovery Layer**: Orchestrator uses AEX `/v1/providers/search` to find agents by skill tags
+2. **A2A is the Execution Layer**: Once discovered, agents communicate directly via A2A protocol
+3. **HTTP in Development**: `ENVIRONMENT=development` allows HTTP URLs for Docker networking
+4. **Docker Hostnames**: Agents register with Docker service names (not localhost)
+5. **Skill-based Matching**: Provider capabilities are matched against subtask skill tags

--- a/documents/a2a-integration/FINAL_IMPLEMENTATION_PLAN.md
+++ b/documents/a2a-integration/FINAL_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,591 @@
+# AEX + A2A Integration - Final Implementation Plan
+
+**Version:** 1.0 | **Date:** January 2, 2026 | **Status:** APPROVED
+
+---
+
+## 1. Project Overview
+
+### 1.1 Objective
+Integrate Agent Exchange (AEX) with the A2A Protocol to create an intelligent agent marketplace with:
+- **Smart Discovery**: A2A Agent Card-based provider registration
+- **Competitive Bidding**: LLM-assisted bid evaluation
+- **Trust & Reputation**: Performance-based scoring
+- **Direct Execution**: A2A protocol for agent-to-agent communication
+- **Settlement**: Automated payment with 15% platform fee
+
+### 1.2 Decisions Summary
+
+| Decision | Choice |
+|----------|--------|
+| **Demo Domains** | Legal + Travel |
+| **LLMs** | Claude, GPT-4, Gemini (one per agent) |
+| **Agent Framework** | LangGraph (consistent across all agents) |
+| **Bidding** | LLM-assisted evaluation (simulated for demo) |
+| **Primary Deployment** | Google Cloud Platform (GCP) |
+| **Secondary Deployment** | AWS (future) |
+
+---
+
+## 2. Demo Architecture
+
+### 2.1 Agent Landscape
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DEMO ARCHITECTURE                                  │
+│                                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                         USER INTERFACE                               │   │
+│  │                      (Mesop Web Application)                         │   │
+│  └───────────────────────────────┬─────────────────────────────────────┘   │
+│                                  │                                          │
+│                                  ▼                                          │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                    ORCHESTRATOR AGENT (Consumer)                     │   │
+│  │                                                                      │   │
+│  │  Framework: LangGraph          LLM: Claude                          │   │
+│  │  Role: Task decomposition, AEX integration, Result aggregation      │   │
+│  │                                                                      │   │
+│  │  Capabilities:                                                       │   │
+│  │  • Parse user requests                                              │   │
+│  │  • Identify required skills                                         │   │
+│  │  • Submit work to AEX                                               │   │
+│  │  • Execute A2A calls to providers                                   │   │
+│  │  • Aggregate and present results                                    │   │
+│  └───────────────────────────────┬─────────────────────────────────────┘   │
+│                                  │                                          │
+│              ┌───────────────────┼───────────────────┐                     │
+│              │                   │                   │                      │
+│              ▼                   ▼                   ▼                      │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐            │
+│  │   AGENT EXCHANGE │  │                 │  │                 │            │
+│  │   (Marketplace)  │  │                 │  │                 │            │
+│  │                  │  │                 │  │                 │            │
+│  │ • Agent Registry │  │                 │  │                 │            │
+│  │ • Bid Evaluation │  │                 │  │                 │            │
+│  │ • Contract Award │  │                 │  │                 │            │
+│  │ • Settlement     │  │                 │  │                 │            │
+│  └────────┬─────────┘  │                 │  │                 │            │
+│           │            │                 │  │                 │            │
+│           │ Discovery  │                 │  │                 │            │
+│           │ & Bidding  │                 │  │                 │            │
+│           ▼            │                 │  │                 │            │
+│  ┌─────────────────────┴─────────────────┴──┴─────────────────┐            │
+│  │                    PROVIDER AGENTS                          │            │
+│  │                                                             │            │
+│  │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────┐ │            │
+│  │  │  LEGAL AGENT    │  │  TRAVEL AGENT   │  │ LEGAL AGENT │ │            │
+│  │  │  (Provider A)   │  │  (Provider B)   │  │ (Provider C)│ │            │
+│  │  │                 │  │                 │  │             │ │            │
+│  │  │ LLM: Claude     │  │ LLM: GPT-4      │  │ LLM: Gemini │ │            │
+│  │  │ Framework:      │  │ Framework:      │  │ Framework:  │ │            │
+│  │  │ LangGraph       │  │ LangGraph       │  │ LangGraph   │ │            │
+│  │  │                 │  │                 │  │             │ │            │
+│  │  │ Skills:         │  │ Skills:         │  │ Skills:     │ │            │
+│  │  │ • contract_     │  │ • flight_       │  │ • contract_ │ │            │
+│  │  │   review        │  │   booking       │  │   review    │ │            │
+│  │  │ • legal_        │  │ • hotel_        │  │ • compliance│ │            │
+│  │  │   research      │  │   booking       │  │   _check    │ │            │
+│  │  │ • compliance    │  │ • itinerary_    │  │             │ │            │
+│  │  │                 │  │   planning      │  │             │ │            │
+│  │  └─────────────────┘  └─────────────────┘  └─────────────┘ │            │
+│  │                                                             │            │
+│  │  All agents expose: /.well-known/agent-card.json           │            │
+│  │  All agents implement: A2A JSON-RPC Server                 │            │
+│  └─────────────────────────────────────────────────────────────┘            │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Agent Specifications
+
+#### Legal Agent A (Claude)
+```yaml
+name: "Legal Counsel Agent"
+description: "Expert contract review and legal document analysis"
+endpoint: "https://legal-agent-a.aex-demo.example/a2a"
+llm: "claude-3-5-sonnet"
+framework: "LangGraph"
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Analyze contracts for risks, obligations, and terms"
+    tags: ["legal", "contracts", "review", "risk-analysis"]
+    input_modes: ["text/plain", "application/pdf"]
+    output_modes: ["text/plain", "application/json"]
+  - id: "legal_research"
+    name: "Legal Research"
+    description: "Research case law, regulations, and legal precedents"
+    tags: ["legal", "research", "regulations", "case-law"]
+pricing:
+  base_rate: 25.00  # USD per task
+  complexity_multiplier: true
+```
+
+#### Travel Agent (GPT-4)
+```yaml
+name: "Travel Concierge Agent"
+description: "Comprehensive travel planning and booking assistance"
+endpoint: "https://travel-agent.aex-demo.example/a2a"
+llm: "gpt-4-turbo"
+framework: "LangGraph"
+skills:
+  - id: "flight_booking"
+    name: "Flight Booking"
+    description: "Search and book optimal flight itineraries"
+    tags: ["travel", "flights", "booking", "airlines"]
+    input_modes: ["text/plain", "application/json"]
+    output_modes: ["text/plain", "application/json"]
+  - id: "hotel_booking"
+    name: "Hotel Booking"
+    description: "Find and reserve accommodations"
+    tags: ["travel", "hotels", "accommodation", "booking"]
+  - id: "itinerary_planning"
+    name: "Itinerary Planning"
+    description: "Create comprehensive travel itineraries"
+    tags: ["travel", "planning", "itinerary", "schedule"]
+pricing:
+  base_rate: 15.00
+  per_booking_fee: 5.00
+```
+
+#### Legal Agent B (Gemini)
+```yaml
+name: "Compliance & Research Agent"
+description: "Regulatory compliance and international law research"
+endpoint: "https://legal-agent-b.aex-demo.example/a2a"
+llm: "gemini-1.5-pro"
+framework: "LangGraph"
+skills:
+  - id: "contract_review"
+    name: "Contract Review"
+    description: "Review contracts with focus on international compliance"
+    tags: ["legal", "contracts", "review", "international"]
+  - id: "compliance_check"
+    name: "Compliance Check"
+    description: "Verify regulatory compliance across jurisdictions"
+    tags: ["compliance", "regulations", "gdpr", "international"]
+pricing:
+  base_rate: 20.00
+```
+
+### 2.3 Demo Scenario Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         DEMO SCENARIO                                        │
+│                                                                             │
+│  USER REQUEST:                                                              │
+│  "I'm traveling to Berlin next week for a business meeting. I need to:     │
+│   1. Review the partnership contract before I go                           │
+│   2. Book flights and hotel                                                │
+│   3. Understand German business regulations"                               │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 1: TASK DECOMPOSITION (Orchestrator)                                 │
+│  ─────────────────────────────────────────                                  │
+│  Orchestrator analyzes request and identifies 3 subtasks:                  │
+│                                                                             │
+│  Task A: Contract Review                                                   │
+│    └─ Required skills: ["contract_review", "legal"]                        │
+│                                                                             │
+│  Task B: Travel Booking                                                    │
+│    └─ Required skills: ["flight_booking", "hotel_booking"]                 │
+│                                                                             │
+│  Task C: Compliance Research                                               │
+│    └─ Required skills: ["compliance_check", "regulations", "germany"]      │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 2: AGENT DISCOVERY (AEX)                                             │
+│  ─────────────────────────────                                              │
+│                                                                             │
+│  Task A Query: GET /v1/providers/search?skill_tag=contract_review          │
+│    └─ Matched: Legal Agent A (Claude), Legal Agent B (Gemini)              │
+│                                                                             │
+│  Task B Query: GET /v1/providers/search?skill_tag=flight_booking           │
+│    └─ Matched: Travel Agent (GPT-4)                                        │
+│                                                                             │
+│  Task C Query: GET /v1/providers/search?skill_tag=compliance_check         │
+│    └─ Matched: Legal Agent B (Gemini)                                      │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 3: BIDDING (AEX + LLM Evaluation)                                    │
+│  ──────────────────────────────────────                                     │
+│                                                                             │
+│  Task A - Contract Review:                                                 │
+│  ┌──────────────────┬─────────┬───────────┬───────────┬─────────┐         │
+│  │ Provider         │ Price   │ Trust     │ Conf.     │ Score   │         │
+│  ├──────────────────┼─────────┼───────────┼───────────┼─────────┤         │
+│  │ Legal Agent A    │ $30     │ 0.92      │ 0.95      │ 0.87    │ ← WIN  │
+│  │ Legal Agent B    │ $25     │ 0.78      │ 0.85      │ 0.76    │         │
+│  └──────────────────┴─────────┴───────────┴───────────┴─────────┘         │
+│                                                                             │
+│  Task B - Travel Booking:                                                  │
+│  ┌──────────────────┬─────────┬───────────┬───────────┬─────────┐         │
+│  │ Provider         │ Price   │ Trust     │ Conf.     │ Score   │         │
+│  ├──────────────────┼─────────┼───────────┼───────────┼─────────┤         │
+│  │ Travel Agent     │ $20     │ 0.88      │ 0.90      │ 0.85    │ ← WIN  │
+│  └──────────────────┴─────────┴───────────┴───────────┴─────────┘         │
+│                                                                             │
+│  Task C - Compliance Research:                                             │
+│  ┌──────────────────┬─────────┬───────────┬───────────┬─────────┐         │
+│  │ Provider         │ Price   │ Trust     │ Conf.     │ Score   │         │
+│  ├──────────────────┼─────────┼───────────┼───────────┼─────────┤         │
+│  │ Legal Agent B    │ $20     │ 0.78      │ 0.88      │ 0.80    │ ← WIN  │
+│  └──────────────────┴─────────┴───────────┴───────────┴─────────┘         │
+│                                                                             │
+│  LLM Bid Evaluator considers:                                              │
+│  • Price competitiveness                                                   │
+│  • Provider trust score history                                            │
+│  • Skill match quality                                                     │
+│  • Response time SLA                                                       │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 4: CONTRACT AWARD (AEX)                                              │
+│  ────────────────────────────                                               │
+│                                                                             │
+│  Three contracts awarded:                                                  │
+│                                                                             │
+│  Contract 1: Legal Agent A for Contract Review                             │
+│    └─ A2A Endpoint: https://legal-agent-a.aex-demo.example/a2a            │
+│    └─ Contract Token: eyJhbGciOiJFUzI1NiIs...                             │
+│                                                                             │
+│  Contract 2: Travel Agent for Travel Booking                               │
+│    └─ A2A Endpoint: https://travel-agent.aex-demo.example/a2a             │
+│    └─ Contract Token: eyJhbGciOiJFUzI1NiIs...                             │
+│                                                                             │
+│  Contract 3: Legal Agent B for Compliance Research                         │
+│    └─ A2A Endpoint: https://legal-agent-b.aex-demo.example/a2a            │
+│    └─ Contract Token: eyJhbGciOiJFUzI1NiIs...                             │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 5: A2A EXECUTION (Direct Agent-to-Agent)                             │
+│  ─────────────────────────────────────────────                              │
+│                                                                             │
+│  Orchestrator executes in parallel:                                        │
+│                                                                             │
+│  POST https://legal-agent-a.aex-demo.example/a2a                           │
+│  Authorization: Bearer {contract_token_1}                                  │
+│  Body: {"jsonrpc":"2.0","method":"message/send","params":{                 │
+│    "message":{"role":"user","parts":[{"text":"Review this contract..."}]}  │
+│  }}                                                                         │
+│                                                                             │
+│  POST https://travel-agent.aex-demo.example/a2a                            │
+│  Authorization: Bearer {contract_token_2}                                  │
+│  Body: {"jsonrpc":"2.0","method":"message/send","params":{                 │
+│    "message":{"role":"user","parts":[{"text":"Book flight to Berlin..."}]} │
+│  }}                                                                         │
+│                                                                             │
+│  POST https://legal-agent-b.aex-demo.example/a2a                           │
+│  Authorization: Bearer {contract_token_3}                                  │
+│  Body: {"jsonrpc":"2.0","method":"message/send","params":{                 │
+│    "message":{"role":"user","parts":[{"text":"Research German regs..."}]}  │
+│  }}                                                                         │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  STEP 6: SETTLEMENT (AEX)                                                  │
+│  ────────────────────────                                                   │
+│                                                                             │
+│  Total Cost: $70.00                                                        │
+│  ┌─────────────────┬──────────┬──────────────┬────────────────┐           │
+│  │ Provider        │ Amount   │ Platform Fee │ Provider Payout│           │
+│  ├─────────────────┼──────────┼──────────────┼────────────────┤           │
+│  │ Legal Agent A   │ $30.00   │ $4.50        │ $25.50         │           │
+│  │ Travel Agent    │ $20.00   │ $3.00        │ $17.00         │           │
+│  │ Legal Agent B   │ $20.00   │ $3.00        │ $17.00         │           │
+│  ├─────────────────┼──────────┼──────────────┼────────────────┤           │
+│  │ TOTAL           │ $70.00   │ $10.50 (15%) │ $59.50         │           │
+│  └─────────────────┴──────────┴──────────────┴────────────────┘           │
+│                                                                             │
+│  Trust scores updated based on outcomes.                                   │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  FINAL OUTPUT TO USER:                                                     │
+│  ─────────────────────                                                      │
+│                                                                             │
+│  "Here's your complete business trip preparation:                          │
+│                                                                             │
+│   📋 CONTRACT REVIEW:                                                      │
+│   The partnership agreement has 3 key risk areas:                          │
+│   1. Liability clause (Section 4.2) needs revision                         │
+│   2. IP ownership unclear in Appendix B                                    │
+│   3. Termination notice period too short (30 days)                         │
+│                                                                             │
+│   ✈️ TRAVEL BOOKED:                                                        │
+│   Flight: LHR → BER, Jan 8, 09:15 (BA 984) - €245                         │
+│   Return: BER → LHR, Jan 11, 18:30 (BA 987) - €198                         │
+│   Hotel: Hotel Adlon Kempinski, 3 nights - €890                            │
+│                                                                             │
+│   📜 GERMAN REGULATIONS:                                                   │
+│   Key compliance requirements for your industry:                           │
+│   1. GDPR applies - ensure data processing agreement                       │
+│   2. German Commercial Code (HGB) partnership rules                        │
+│   3. No specific licensing required for your sector"                       │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. GCP Deployment Architecture
+
+### 3.1 Infrastructure Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        GCP DEPLOYMENT ARCHITECTURE                          │
+│                                                                             │
+│  ┌───────────────────────────────────────────────────────────────────────┐ │
+│  │                        Google Cloud Platform                          │ │
+│  │                                                                       │ │
+│  │  ┌─────────────────────────────────────────────────────────────────┐ │ │
+│  │  │                     Cloud Load Balancer                         │ │ │
+│  │  │                    (Global HTTP/HTTPS)                          │ │ │
+│  │  └─────────────────────────────┬───────────────────────────────────┘ │ │
+│  │                                │                                     │ │
+│  │              ┌─────────────────┼─────────────────┐                   │ │
+│  │              │                 │                 │                   │ │
+│  │              ▼                 ▼                 ▼                   │ │
+│  │  ┌───────────────┐ ┌───────────────┐ ┌───────────────────────────┐  │ │
+│  │  │  Cloud Run    │ │  Cloud Run    │ │      Cloud Run            │  │ │
+│  │  │  (AEX APIs)   │ │  (Demo UI)    │ │   (Provider Agents)       │  │ │
+│  │  │               │ │               │ │                           │  │ │
+│  │  │ • gateway     │ │ • Mesop App   │ │ • legal-agent-a (Claude)  │  │ │
+│  │  │ • work-pub    │ │               │ │ • legal-agent-b (Gemini)  │  │ │
+│  │  │ • bid-gateway │ │               │ │ • travel-agent (GPT-4)    │  │ │
+│  │  │ • bid-eval    │ │               │ │ • orchestrator (Claude)   │  │ │
+│  │  │ • contract    │ │               │ │                           │  │ │
+│  │  │ • settlement  │ │               │ │                           │  │ │
+│  │  │ • registry    │ │               │ │                           │  │ │
+│  │  │ • trust       │ │               │ │                           │  │ │
+│  │  │ • identity    │ │               │ │                           │  │ │
+│  │  │ • telemetry   │ │               │ │                           │  │ │
+│  │  └───────┬───────┘ └───────────────┘ └───────────────────────────┘  │ │
+│  │          │                                                           │ │
+│  │          │                                                           │ │
+│  │          ▼                                                           │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐  │ │
+│  │  │                         Data Layer                            │  │ │
+│  │  │                                                               │  │ │
+│  │  │  ┌─────────────────┐  ┌─────────────────┐  ┌───────────────┐ │  │ │
+│  │  │  │    Firestore    │  │  Cloud Storage  │  │ Secret Manager│ │  │ │
+│  │  │  │   (Documents)   │  │   (Artifacts)   │  │  (API Keys)   │ │  │ │
+│  │  │  │                 │  │                 │  │               │ │  │ │
+│  │  │  │ • work_specs    │  │ • contracts     │  │ • LLM keys    │ │  │ │
+│  │  │  │ • providers     │  │ • documents     │  │ • JWT keys    │ │  │ │
+│  │  │  │ • bids          │  │ • results       │  │ • service creds│ │  │ │
+│  │  │  │ • contracts     │  │                 │  │               │ │  │ │
+│  │  │  │ • ledger        │  │                 │  │               │ │  │ │
+│  │  │  │ • trust_scores  │  │                 │  │               │ │  │ │
+│  │  │  └─────────────────┘  └─────────────────┘  └───────────────┘ │  │ │
+│  │  │                                                               │  │ │
+│  │  └───────────────────────────────────────────────────────────────┘  │ │
+│  │                                                                       │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐  │ │
+│  │  │                      Observability                            │  │ │
+│  │  │                                                               │  │ │
+│  │  │  ┌─────────────────┐  ┌─────────────────┐  ┌───────────────┐ │  │ │
+│  │  │  │ Cloud Logging   │  │ Cloud Monitoring│  │ Cloud Trace   │ │  │ │
+│  │  │  └─────────────────┘  └─────────────────┘  └───────────────┘ │  │ │
+│  │  │                                                               │  │ │
+│  │  └───────────────────────────────────────────────────────────────┘  │ │
+│  │                                                                       │ │
+│  └───────────────────────────────────────────────────────────────────────┘ │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Cloud Run Services
+
+| Service | Image | Memory | CPU | Min/Max Instances |
+|---------|-------|--------|-----|-------------------|
+| aex-gateway | gcr.io/PROJECT/aex-gateway | 256Mi | 1 | 1/10 |
+| aex-work-publisher | gcr.io/PROJECT/aex-work-publisher | 512Mi | 1 | 1/5 |
+| aex-bid-gateway | gcr.io/PROJECT/aex-bid-gateway | 256Mi | 1 | 1/5 |
+| aex-bid-evaluator | gcr.io/PROJECT/aex-bid-evaluator | 512Mi | 1 | 1/3 |
+| aex-contract-engine | gcr.io/PROJECT/aex-contract-engine | 256Mi | 1 | 1/5 |
+| aex-settlement | gcr.io/PROJECT/aex-settlement | 256Mi | 1 | 1/3 |
+| aex-provider-registry | gcr.io/PROJECT/aex-provider-registry | 256Mi | 1 | 1/5 |
+| aex-trust-broker | gcr.io/PROJECT/aex-trust-broker | 256Mi | 1 | 1/3 |
+| aex-identity | gcr.io/PROJECT/aex-identity | 256Mi | 1 | 1/3 |
+| aex-telemetry | gcr.io/PROJECT/aex-telemetry | 256Mi | 1 | 1/3 |
+| demo-ui | gcr.io/PROJECT/demo-ui | 512Mi | 1 | 1/3 |
+| legal-agent-a | gcr.io/PROJECT/legal-agent-a | 1Gi | 2 | 0/3 |
+| legal-agent-b | gcr.io/PROJECT/legal-agent-b | 1Gi | 2 | 0/3 |
+| travel-agent | gcr.io/PROJECT/travel-agent | 1Gi | 2 | 0/3 |
+| orchestrator | gcr.io/PROJECT/orchestrator | 1Gi | 2 | 1/3 |
+
+### 3.3 Estimated Monthly Cost (Demo/Staging)
+
+| Service | Estimated Cost |
+|---------|---------------|
+| Cloud Run (14 services) | $50-100 |
+| Firestore | $10-20 |
+| Cloud Storage | $5 |
+| Secret Manager | $2 |
+| Load Balancer | $20 |
+| Cloud Logging/Monitoring | $10 |
+| **LLM API Costs (variable)** | $50-200 |
+| **Total** | **~$150-350/month** |
+
+---
+
+## 4. Implementation Phases (Updated)
+
+### Phase 1: A2A Registry Integration (Week 1-2)
+
+```
+Week 1:
+├── Day 1-2: Agent Card Package
+│   ├── Create src/internal/agentcard/types.go
+│   ├── Create src/internal/agentcard/fetcher.go
+│   └── Create src/internal/agentcard/validator.go
+│
+├── Day 3-4: Provider Registry Updates
+│   ├── Update provider model with Agent Card fields
+│   ├── Implement Agent Card fetch on registration
+│   └── Create skills indexing logic
+│
+└── Day 5: Search API
+    ├── Implement GET /v1/providers/search
+    └── Add filtering by skills/tags
+
+Week 2:
+├── Day 1-2: Contract Engine Updates
+│   ├── Add A2A endpoint to award response
+│   └── Include protocol binding info
+│
+├── Day 3-4: Testing
+│   ├── Unit tests for Agent Card components
+│   └── Integration tests for registration flow
+│
+└── Day 5: Documentation
+    └── Update API docs with new endpoints
+```
+
+### Phase 2: Contract Token System (Week 3)
+
+```
+Week 3:
+├── Day 1-2: Token Service
+│   ├── Create src/internal/token/token.go
+│   ├── Implement JWT generation (ES256)
+│   └── Create JWKS endpoint
+│
+├── Day 3: Contract Engine Integration
+│   ├── Generate token on award
+│   └── Include in response
+│
+├── Day 4: Validation SDK
+│   ├── Go SDK for token validation
+│   └── Python SDK for providers
+│
+└── Day 5: Testing
+    └── End-to-end token flow tests
+```
+
+### Phase 3: Demo Agents (Week 4-5)
+
+```
+Week 4:
+├── Day 1-2: Agent Framework Setup
+│   ├── Create demo/agents/ structure
+│   ├── Setup LangGraph base agent
+│   └── Create A2A server wrapper
+│
+├── Day 3-4: Legal Agent A (Claude)
+│   ├── Implement contract_review skill
+│   ├── Implement legal_research skill
+│   └── Create agent-card.json
+│
+└── Day 5: Legal Agent B (Gemini)
+    ├── Implement contract_review skill
+    └── Implement compliance_check skill
+
+Week 5:
+├── Day 1-2: Travel Agent (GPT-4)
+│   ├── Implement flight_booking skill
+│   ├── Implement hotel_booking skill
+│   └── Implement itinerary_planning skill
+│
+├── Day 3: Orchestrator Agent
+│   ├── Implement task decomposition
+│   ├── Implement AEX client
+│   └── Implement result aggregation
+│
+├── Day 4-5: Demo UI (Mesop)
+    ├── User input panel
+    ├── Agent discovery view
+    ├── Bidding visualization
+    ├── Execution trace
+    └── Settlement display
+```
+
+### Phase 4: GCP Deployment (Week 6)
+
+```
+Week 6:
+├── Day 1-2: Infrastructure Setup
+│   ├── Create GCP project
+│   ├── Setup Firestore
+│   ├── Configure Secret Manager
+│   └── Setup Cloud Build
+│
+├── Day 3-4: Deploy Services
+│   ├── Deploy AEX services
+│   ├── Deploy demo agents
+│   ├── Deploy UI
+│   └── Configure load balancer
+│
+└── Day 5: Testing & Demo
+    ├── End-to-end demo flow
+    ├── Performance testing
+    └── Documentation
+```
+
+---
+
+## 5. Success Criteria
+
+### Technical Validation
+- [ ] Agent Card fetched from `/.well-known/agent-card.json`
+- [ ] Skills indexed and searchable
+- [ ] Contract token generated and validated
+- [ ] A2A execution completes successfully
+- [ ] Settlement calculates correct fees
+
+### Demo Validation
+- [ ] User can input multi-task request
+- [ ] UI shows discovered agents
+- [ ] Bidding process visible
+- [ ] All 3 provider agents respond via A2A
+- [ ] Results aggregated and displayed
+- [ ] Settlement breakdown shown
+
+### Performance Targets
+- [ ] Agent discovery: < 500ms
+- [ ] Bid evaluation: < 2s
+- [ ] A2A task execution: < 30s per agent
+- [ ] End-to-end demo: < 2 minutes
+
+---
+
+## 6. Next Steps
+
+1. **Get Final Approval** on this plan
+2. **Start Phase 1.1**: Create Agent Card package
+3. **Setup Development Environment**: Ensure all LLM API keys available
+
+---
+
+**Document Status:** FINAL
+**Approval Required:** Yes
+**Next Action:** Begin Phase 1 implementation upon approval

--- a/documents/a2a-integration/IMPLEMENTATION_TODO.md
+++ b/documents/a2a-integration/IMPLEMENTATION_TODO.md
@@ -1,0 +1,431 @@
+# A2A Integration - Implementation TODO
+
+**Created:** January 2, 2026
+**Status:** PLANNING
+
+---
+
+## Implementation Phases Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Phase 1: A2A Registry       │  Phase 2: Contract Token   │  Phase 3: Demo │
+│  ─────────────────────────   │  ────────────────────────  │  ────────────  │
+│  • Agent Card Resolver       │  • JWT Token Service       │  • Legal Agent │
+│  • Skills Indexing           │  • JWKS Endpoint           │  • Travel Agent│
+│  • Search API                │  • Provider SDK            │  • Compliance  │
+│  • Award A2A Endpoint        │  • Token Validation        │  • Orchestrator│
+│                              │                            │  • Demo UI     │
+│  Duration: 2-3 weeks         │  Duration: 1-2 weeks       │  Duration: 2-3 │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: A2A-Compatible Registry
+
+### 1.1 Agent Card Resolver
+- [ ] **Create `internal/agentcard` package**
+  - [ ] Define AgentCard Go struct matching A2A spec
+  - [ ] Define AgentSkill struct
+  - [ ] Define AgentCapabilities struct
+  - [ ] Define SupportedInterface struct
+
+- [ ] **Implement Agent Card Fetcher**
+  - [ ] `FetchAgentCard(baseURL string) (*AgentCard, error)`
+  - [ ] Try `/.well-known/agent-card.json` first
+  - [ ] Fallback to `/.well-known/agent.json` on 404
+  - [ ] Validate JSON schema
+  - [ ] Parse protocol_version
+  - [ ] Handle HTTP errors gracefully
+
+- [ ] **Add Agent Card Caching**
+  - [ ] In-memory cache with TTL (configurable, default 1 hour)
+  - [ ] Force refresh option
+  - [ ] Cache invalidation on provider update
+
+- [ ] **Add Agent Card Validation**
+  - [ ] Required fields check (name, supported_interfaces)
+  - [ ] URL format validation
+  - [ ] Skills schema validation
+  - [ ] Security schemes validation
+
+### 1.2 Update Provider Registry Service
+- [ ] **Update Provider Model**
+  ```go
+  type Provider struct {
+    // Existing fields...
+    AgentCardURL      string          `json:"agent_card_url"`
+    AgentCardRaw      json.RawMessage `json:"agent_card_raw"`
+    ProtocolVersion   string          `json:"protocol_version"`
+    PreferredInterface Interface      `json:"preferred_interface"`
+    SkillsIndex       []SkillIndex    `json:"skills_index"`
+    Capabilities      Capabilities    `json:"capabilities"`
+    SecuritySchemes   []string        `json:"security_schemes"`
+    LastCardRefresh   time.Time       `json:"last_card_refresh"`
+  }
+  ```
+
+- [ ] **Update Registration Endpoint**
+  - [ ] Accept `agent_base_url` OR `agent_card_url`
+  - [ ] Fetch and validate Agent Card
+  - [ ] Extract and index skills/tags
+  - [ ] Store raw card + projection
+  - [ ] Return verification status
+
+- [ ] **Add Skills Search API**
+  - [ ] `GET /v1/providers/search`
+  - [ ] Query by `skill_id`
+  - [ ] Query by `skill_tag` (multiple)
+  - [ ] Query by `requires_streaming`
+  - [ ] Query by `requires_push_notifications`
+  - [ ] Query by `min_trust_score`
+  - [ ] Pagination support
+
+- [ ] **Add Agent Card Refresh Job**
+  - [ ] Background goroutine to refresh cards
+  - [ ] Configurable refresh interval
+  - [ ] Update skills index on change
+  - [ ] Log/alert on fetch failures
+
+### 1.3 Update Contract Engine
+- [ ] **Enhance Award Response**
+  ```go
+  type AwardResponse struct {
+    // Existing fields...
+    ProviderA2AEndpoint string   `json:"provider_a2a_endpoint"`
+    ProtocolBinding     string   `json:"protocol_binding"`
+    SecuritySchemes     []string `json:"security_schemes"`
+    ContractToken       string   `json:"contract_token"`
+  }
+  ```
+
+- [ ] **Lookup Provider A2A Endpoint on Award**
+  - [ ] Fetch provider from registry
+  - [ ] Extract preferred_interface URL
+  - [ ] Include protocol binding info
+
+### 1.4 Testing
+- [ ] Unit tests for Agent Card Fetcher
+- [ ] Unit tests for Agent Card Validation
+- [ ] Integration tests for provider registration with Agent Card
+- [ ] Integration tests for skills search API
+- [ ] Mock A2A agent for testing
+
+---
+
+## Phase 2: Contract Token & Auth
+
+### 2.1 Contract Token Service
+- [ ] **Create `internal/token` package**
+  - [ ] Define ContractTokenClaims struct
+  - [ ] Generate ES256 key pair (or load from config)
+  - [ ] Implement `GenerateContractToken(claims) (string, error)`
+  - [ ] Implement `ValidateContractToken(token) (*Claims, error)`
+
+- [ ] **Token Claims Structure**
+  ```go
+  type ContractTokenClaims struct {
+    Issuer        string   `json:"iss"` // "aex"
+    Audience      string   `json:"aud"` // provider domain
+    Subject       string   `json:"sub"` // consumer agent ID
+    WorkID        string   `json:"work_id"`
+    ContractID    string   `json:"contract_id"`
+    ProviderID    string   `json:"provider_id"`
+    PriceMicrounits int64  `json:"price_microunits"`
+    Scope         []string `json:"scope"` // ["a2a:message:send"]
+    ExpiresAt     int64    `json:"exp"`
+    IssuedAt      int64    `json:"iat"`
+    TokenID       string   `json:"jti"`
+  }
+  ```
+
+- [ ] **Integrate Token Generation in Award Flow**
+  - [ ] Generate token after bid selection
+  - [ ] Include in award response
+  - [ ] Store token hash in contract record
+
+### 2.2 JWKS Endpoint
+- [ ] **Create `/.well-known/jwks.json` endpoint**
+  - [ ] Expose public key for token verification
+  - [ ] Support key rotation (kid)
+  - [ ] Add to gateway routes
+
+### 2.3 Provider SDK for Token Validation
+- [ ] **Go SDK** (`pkg/aex-token`)
+  - [ ] `ValidateContractToken(token, jwksURL) (*Claims, error)`
+  - [ ] Fetch and cache JWKS
+  - [ ] Verify signature
+  - [ ] Validate claims (expiry, audience)
+
+- [ ] **Python SDK** (`aex-token-python`)
+  - [ ] Same functionality as Go SDK
+  - [ ] Publish to PyPI (optional)
+
+### 2.4 Testing
+- [ ] Unit tests for token generation
+- [ ] Unit tests for token validation
+- [ ] Integration test: award → token → validation
+- [ ] Test token expiry handling
+
+---
+
+## Phase 3: Demo Agents
+
+### 3.1 Demo Infrastructure
+- [ ] **Create `demo/` directory structure**
+  ```
+  demo/
+  ├── docker-compose.yml
+  ├── agents/
+  │   ├── legal/
+  │   ├── travel/
+  │   ├── compliance/
+  │   └── orchestrator/
+  ├── ui/
+  │   └── mesop/
+  └── scripts/
+      ├── setup.sh
+      └── seed-data.sh
+  ```
+
+- [ ] **Docker Compose for Demo**
+  - [ ] All AEX services
+  - [ ] MongoDB
+  - [ ] 3 provider agents
+  - [ ] 1 orchestrator agent
+  - [ ] Mesop UI
+  - [ ] Proper networking
+
+### 3.2 Legal Agent (Provider)
+- [ ] **Setup Python A2A Agent**
+  - [ ] Use a2a-python SDK
+  - [ ] LangGraph + Claude integration
+  - [ ] Implement A2A server
+
+- [ ] **Define Agent Card**
+  ```json
+  {
+    "name": "Legal Assistant Agent",
+    "description": "Contract review and legal research",
+    "supported_interfaces": [{
+      "url": "http://legal-agent:8000/a2a",
+      "protocol_binding": "JSONRPC"
+    }],
+    "skills": [
+      {"id": "contract_review", "name": "Contract Review", "tags": ["legal", "contracts"]},
+      {"id": "legal_research", "name": "Legal Research", "tags": ["legal", "research"]}
+    ],
+    "capabilities": {"streaming": true}
+  }
+  ```
+
+- [ ] **Implement Skills**
+  - [ ] Contract review (analyze document, identify risks)
+  - [ ] Legal research (search regulations, summarize)
+
+- [ ] **AEX Integration**
+  - [ ] Listen for opportunities webhook
+  - [ ] Auto-submit bids
+  - [ ] Accept contract token auth
+  - [ ] Report completion to AEX
+
+### 3.3 Travel Agent (Provider)
+- [ ] **Setup Python A2A Agent**
+  - [ ] Use a2a-python SDK
+  - [ ] CrewAI or AutoGen + GPT-4 integration
+
+- [ ] **Define Agent Card**
+  ```json
+  {
+    "name": "Travel Booking Agent",
+    "description": "Flight, hotel, and itinerary planning",
+    "skills": [
+      {"id": "flight_booking", "tags": ["travel", "flights"]},
+      {"id": "hotel_booking", "tags": ["travel", "hotels"]},
+      {"id": "itinerary_planning", "tags": ["travel", "planning"]}
+    ]
+  }
+  ```
+
+- [ ] **Implement Skills**
+  - [ ] Flight search (mock or real API)
+  - [ ] Hotel search (mock or real API)
+  - [ ] Itinerary creation
+
+### 3.4 Compliance Agent (Provider)
+- [ ] **Setup Python A2A Agent**
+  - [ ] Use a2a-python SDK
+  - [ ] AutoGen + Gemini integration
+
+- [ ] **Define Agent Card**
+  ```json
+  {
+    "name": "Compliance Research Agent",
+    "description": "Regulatory compliance and research",
+    "skills": [
+      {"id": "regulatory_research", "tags": ["compliance", "regulations"]},
+      {"id": "gdpr_compliance", "tags": ["compliance", "gdpr", "europe"]}
+    ]
+  }
+  ```
+
+- [ ] **Implement Skills**
+  - [ ] Regulatory research
+  - [ ] GDPR compliance check
+
+### 3.5 Orchestrator Agent (Consumer/Host)
+- [ ] **Setup Python A2A Agent**
+  - [ ] Use a2a-python SDK
+  - [ ] Google ADK or custom orchestration
+
+- [ ] **Implement AEX Client**
+  - [ ] Submit work to AEX
+  - [ ] Handle bid notifications
+  - [ ] Accept award response
+  - [ ] Execute via A2A using contract token
+
+- [ ] **Implement Task Decomposition**
+  - [ ] Parse user request
+  - [ ] Identify required skills
+  - [ ] Create sub-tasks
+  - [ ] Route to AEX marketplace
+
+- [ ] **Implement Result Aggregation**
+  - [ ] Collect responses from all providers
+  - [ ] Combine into unified response
+  - [ ] Handle partial failures
+
+### 3.6 Demo UI (Mesop)
+- [ ] **User Input Panel**
+  - [ ] Text area for user request
+  - [ ] Submit button
+
+- [ ] **Agent Discovery View**
+  - [ ] Show matched agents from AEX
+  - [ ] Display skills and trust scores
+
+- [ ] **Bidding Visualization**
+  - [ ] Show incoming bids
+  - [ ] Display bid evaluation scores
+  - [ ] Highlight winner
+
+- [ ] **Execution Trace View**
+  - [ ] Show A2A messages to each provider
+  - [ ] Display task status updates
+  - [ ] Show streaming responses
+
+- [ ] **Settlement View**
+  - [ ] Show cost breakdown
+  - [ ] Display platform fee
+  - [ ] Show settlement status
+
+### 3.7 Testing
+- [ ] End-to-end demo flow test
+- [ ] Test each agent individually
+- [ ] Test orchestrator with mock providers
+- [ ] Load test with multiple concurrent requests
+
+---
+
+## Phase 4: Trust & Governance (Future)
+
+### 4.1 Agent Card Signatures
+- [ ] Implement JWS verification for Agent Cards
+- [ ] Add signature status to provider model
+- [ ] Create verification tiers
+
+### 4.2 Extended Agent Cards
+- [ ] Support authenticated Agent Card fetch
+- [ ] Private skills indexing
+- [ ] Access control for sensitive endpoints
+
+---
+
+## Documentation
+
+- [ ] Update QUICKSTART.md with A2A integration guide
+- [ ] Add demo setup instructions
+- [ ] Document Agent Card registration process
+- [ ] Document contract token flow
+- [ ] API documentation for new endpoints
+- [ ] Provider SDK documentation
+
+---
+
+## Quick Reference: File Changes
+
+### Phase 1 Files
+```
+src/internal/agentcard/           # NEW
+  ├── types.go
+  ├── fetcher.go
+  ├── validator.go
+  ├── cache.go
+  └── fetcher_test.go
+
+src/aex-provider-registry/
+  ├── internal/model/model.go     # UPDATE
+  ├── internal/service/service.go # UPDATE
+  └── internal/httpapi/handlers.go # UPDATE
+
+src/aex-contract-engine/
+  └── internal/model/model.go     # UPDATE
+```
+
+### Phase 2 Files
+```
+src/internal/token/               # NEW
+  ├── token.go
+  ├── claims.go
+  ├── jwks.go
+  └── token_test.go
+
+src/aex-gateway/
+  └── internal/httpapi/router.go  # UPDATE (add JWKS route)
+
+pkg/aex-token/                    # NEW (Go SDK)
+aex-token-python/                 # NEW (Python SDK)
+```
+
+### Phase 3 Files
+```
+demo/                             # NEW
+  ├── docker-compose.yml
+  ├── agents/
+  │   ├── legal/
+  │   │   ├── Dockerfile
+  │   │   ├── agent.py
+  │   │   ├── agent_card.json
+  │   │   └── requirements.txt
+  │   ├── travel/
+  │   ├── compliance/
+  │   └── orchestrator/
+  ├── ui/
+  │   └── mesop/
+  └── scripts/
+```
+
+---
+
+## Success Checklist
+
+### Phase 1 Complete When:
+- [ ] Can register provider with Agent Card URL
+- [ ] Skills are indexed and searchable
+- [ ] Award response includes A2A endpoint
+
+### Phase 2 Complete When:
+- [ ] Contract token generated on award
+- [ ] JWKS endpoint returns public key
+- [ ] SDK can validate tokens
+
+### Phase 3 Complete When:
+- [ ] All 3 provider agents running
+- [ ] Orchestrator can execute multi-agent workflow
+- [ ] Demo UI shows complete journey
+- [ ] Settlement completes correctly
+
+---
+
+**Next Action:** Get user approval, then start Phase 1.1 (Agent Card Resolver)

--- a/documents/a2a-integration/agent-exchange_a2a_integration_design.pdf
+++ b/documents/a2a-integration/agent-exchange_a2a_integration_design.pdf
@@ -1,0 +1,271 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 7 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+8 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 27 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 28 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 612 792 ] /Parent 18 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+16 0 obj
+<<
+/PageMode /UseNone /Pages 18 0 R /Type /Catalog
+>>
+endobj
+17 0 obj
+<<
+/Author (open-experiments / agent-exchange \(draft\)) /CreationDate (D:20260102023956+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260102023956+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (Agent Exchange - A2A Integration Design) /Trapped /False
+>>
+endobj
+18 0 obj
+<<
+/Count 11 /Kids [ 4 0 R 5 0 R 6 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
+  15 0 R ] /Type /Pages
+>>
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1704
+>>
+stream
+Gat=+gN)%,&:O:Slm&(DPXpYB\5-l,FHWMlWM=S3TGNE;,ZGo%!2*n9qXNAF0=jQK1U\l.#(aIX4aXDn@"@-ss./9P^FZ&X5(Y2;`>YIJ3.f*s\6iKh]rI^Kr.@9pXWQJ]lGm^S92sY=OuSuV`\<p:@p%e'7+\[<(DcK'b[5%dff1%gA3bUl**3Aop!hIk7V&4m5)+;IhI@YWBGs>rI(76?QuBKTE;u/?RG)ViJU'A5&'FF%@8:J>GMJ(8C-oEj3pX[D$YVYj2?AO%(r%D:rdGpJYR1u)M^md9`8GQO/@rTMbcnL-5o@FfE5rs5Ko\ombWJ8B_lVkf#s.8.6u=o]5,0eT\!8c<HpB2tBOHL$Yn\$0SX)8Z<#AnSb:PD=[7UmP*&8$63"8R0#9O8'h&$M:TmOZrFI0iArh&:p^$jl9JA#o+E*Ie-L9FEYeHl]'o@a2A*+2`@VcnOfYud?(Yf7)&?m.=7;uOcL\7Jt=?^]%&o"#'(lWmZcN@pbuRiZ/)$qhVF4`19/51Ah?&+I8TD7O_N'/j93"U="e!b^i@,edBKBQ@:Epd/QSAL=oZq=e%L6I(7)pd4gR\5b"f<B?*I<2l(=r!Xc&W\!ALWY@3U"R))h\skkbr$X=<g9gg(gR3)F]T@0^2JWGBI!rX7VfcpJ]g)F<V>S.L7^Erh-%*GbBG=`q'FfOg'aSAe3Nkt>'VZ*,'KP[(!RoB"ah%$_-.+5\P,ahg-*#]=qZ*k6Yb_K%%*sH$CTWQPEJ'7dYiE5rCQmKTEI4o&=lpUE+.4[n5TSMBq$@:4p8F\7JZt.Nkegji_.qkD9ptsrVUW,EkG8e?UD=Z#VbTF2Ye^3MmJLof^\d%4per>).WAJT.qMUfe!7(."Vlud:c%c**-:Gu8d\4.><2ClN11Q2-8DCb"<Dt)cB>$TUZ#QQ4:_V5XtQ%R&q7&PLXXqq:2Hr^WKE24H*P1nHTjR(eYUL*):"buQdU+Eft7Yt:denGUmTS0$[I7/AN)K@^lAoH>789)A*$7T($It4`!\)_?1=>L`]l2*,HRq;Id14BiCG2eOJnl*%m01da\jAq-I&d599`hc4]0XqdLt_&Ecu`a66:Mn%3Dr/$>gca1kJ_l=R,NHQ1nP+S"7uSFlXOPapO-&[_/cr+s&K8^6^DK_t&G>f&ner-'@)1(8Hj:LM$$C>"O0%+d/WF6o36cd=LEu5IOhbFW:b"AsLL1@.knWBVbZk>\(E*0^/k5RO'OElB52C9>R3rAf2f9Oe2>ioaG1K52dihAa-[;;g2CQ?!5OBf,u!G!@".@&9f6RHj-5&MZE^48r9,6NV>\GTq<ed6qKXQ<H*BC$.:)&?EfEC[F+dVa&-Z8i\''8"\@D5EM+8,61ecl$p0Of]Q1E%E92Y_dO7nL]hjTlC$;g\iu"9=n23-/]7J$KW/oNZe'!9_nIm`H(#Cj+DB!CSGCEm=pem)B:?4B.+A#.IUjPY<W@[S:@9tF.G*o6K??+,_9g,M9pu^8`$$/5#]G]kZb:pD;hZ39:S/4[s9Z7iTPcj:7Th([C`l:)Z7p@"?44GE<?e!C6rFLM:D=Ls">84#BMe]jrG=^T^VeuIi.r?.7LMqnrl%!LCaun2Tdhc5&Q<.JjO/A@41R)ZFg.g2\dD^-9$_E55?4885fLe[SO#UE$mGr<kq%h"oHh?1q?,AF>+LcOE'PkAQF3NS-J#B[`.0~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1489
+>>
+stream
+Gat=*gN)%,&:O:Sm%`@@,a,`AcBI651S/;:Bh-YG5q`cTOf1Nq!C4cLf68%,BZ[[G<+Cu#iNefVB?qcV#_1k'QPTWDQSA=M6_(r4"7^UiL?5W.H$T#[VV.AmNG*:gCuC0Hf4K+MDX:(Ea^@<)_Iu-#_Qn\uEXU'?@/12dq&R^#%o+@:Tt)n(a42T>SstUF9GW@i&e$15&&*D4!$7-nin4F_.AXi&9LEEZEbE*mH(3YdJ(@g5_R/hK_d>FqYk\,T8-c$aZB.;Hc<t-uVo*'CNl/tH;YuCZfguX$n4Lun/0&m:cD[96T*tE$cgVlEbWW;V9;A2fB!"H%lN=5jfa:AlV:'@i'D<",iJ<b1gsaP4QV%84)4BL9A+2WmppMh5=jb5VDHo.QScu==blF'nSc%bPUu8mnl(RQ.o)^hmlk,Qho&H`:==E^NK>"NoMB4RaCE6in4.-HA?nKj>!%HYYS%?3C.co<OiCk[:QB&F.0e9b8#M;TPMe)?$=KnMQ0JkV4;NRI`hBOec'22V-<kcST.T6c2%6A8@rA6CXac\Jk8JVRF3l^7A&(*tmalr_MT"OWH[G(f,0Pa1<_6$rIl4cu9M&`UC$eg8(4MSJ@$cd6+lRjsQ,o*d@.9"[<E14B)V0j4m&!k@`>B+"QU]Ma^a::Mkg+&K0&AU*2F^YM.#Z`(EL<LYpc`PTlEe.&<R94K;g`"f(eB8$`)2qRKP=8X+1/uU0i5oJT)lYP_#$>Uo)u/IJ,8A#X-DeeG$V4Yp(NItcN+hF:^MPn-BFm\_fk^f74nRGQ+k4+bpgGNInR'Qu(M\(3&n3ocJC.%J/r=qj.a27HaUuQ-]f5m&l@F=PT!tMRaQo=3Lu2-j$d9R+V\:AXj&,TB@-aQEGi%ZDE<J\GCsqPFgHbs+p>QJ65.c<LH7=j$78?&Z/PM#N=A'q!i?<<Rb>"h]TMJU9Y>>O/?0JmuE4M,/9H)OB@'EV[+l"1L,SdPil,U-2Ogm70#`76b8:1i/%bNeI^fn=DL8(W:%mW,=1$,'jX]C4CKMjNV5(M$/Q=0b1<NjsOfP4nT*ol>]it9T>+JTE3Nb0pF'$i0Snqgn.nA#@L5oI#2b(l;a_-,HQ#"?W)S>KCRCJ>'X!)g/2'$#i:9j2O.$`flR8t7iim?r;u]L&DRCAabNh4rANUD-;^<k$o+-!)3j1MPVF>k/ADQ^P4fKEA!@dE=dR00Fccb0jDO;5R3g?:I:6gL7+J<]Y6kUhJE14[-p6ebN!%nrKs!s%e"`:iglV:fkr*?Q5Vi&fK`SH`=<:E7bPpqHIh1q?.W`RErKd+5Jm9r:To^(%sT>?:Poe]nu]T,kSehh61D'*c0I/333jDEZ=k"FW3Y.c+NdIO%AO:#*kKV5)4?`aKU#qP)F6S@7lVJihT'V$*OZb;Fh6,<`GHMLYM>R@C2\Y:X`>(D-i]Upjm:8Y<$u3%`OI-Wg7(j11R0,Me9h9A(n'SfSf[BD_S]s(U37Yc2~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1190
+>>
+stream
+Gat=*?#Sa]&:Dg-fLMe$aHeA=ESfJd%L@#*Y#bklK7SW?.%;q[.O9/I[-3#.OHO'7NL_u3i=CD(m-Y:;8n`lZ&jGoEkf3i95:)PiZm[BFif"YFl"4r/E7W:X_Sdk:l6`a0I@IWOP'$4@P;JlUVDOm`;d*-7NR)<Y:Q$=mSmN)4?T9(R-,O4Ya64q1*ekS1js(:!V+<#-#OH+DdhedMcF"pp$7^_Rof$c[.+_JDS6-(HgsZ;l$fpR&oY2TZ%@MC\$-h(,3Vpfj5uQl2du'HRW+p/h_p$8B[M<OOq1bk+?_3n6@slhiE<&3uiebu(#rDco7Xh//5$a'.l'r*O2\kmtdkDaN^u*"lgFu-`)mmQss'BKa0ueq#cQ>ds4`Vu)[Rrb6])-f#h.I[AmkCMrF1&\&%f^!eo0o?'-IgqjGdhnLcK#6Mhcm3LR/O[mQu8:RJg1@CmdicfQ5[r)=#'^qrCGk>!Qc<*[k08SBmPmPXVcQo5AoZ!bc0[9=L!5mT-PfKaQ_$j-qGNK%`%DI$+*.C&^arlm@kYchRKD2^W':YdJW-NE,;pMpZUePh\P8qqGT4I.?&BsX.7Dj?"J>pb3,`'^WP;oZ;EO(P0neP-7*r34JbO^6)?JJc(in_JH_Prr:8Zt+7h<rpuT*qs2aa?V]+@A7Xl'T2qL4K"ehk(IIK&/q#9Ie&=#^dra\scr+*L)m!YIl*dEG,d$.QTB+cPi[nTSCFjG,Q$9t#VDr=EO[UoQ]]d/8bEEOp;Mh9^=J8P'u`KVd]FfkBEQ-0B<KK^jj/I\5_3[!2,hQG7,U#6k9bHZ"(h0o5q+8QVE^=@o#"TXkO"-d)t+>(D]_XP2m#Yc)Q<SS&nIqXMohN9Nun<,ZWVc#HkW#LLFWcSi]DM=>Mf!T^>-D+/;==`MPitluNlPK1R#IUlB*2"cd5H'-_GOU"Xn.Mr[H(2#Wh8k2Ldj>nr)>:Sl_-N2/n\%oU<(r06^!M`39T&7G4Z'ZN;>j(#A^`S+InX$UqW[hH%\7=UX'"a"4:4**R_J=ed,1S$=fK.u>O;Pi_f>5Ub?`KemYSeAK-%3^pGE):/C.\YQNN2D(kiM&(C"Z[8+cF*U[daY+=\Logqfab.FrqQ]%lik3/?0M&Y:7YX.UO3WP`u9#g%opX*k-*<*o6ECOC:/"KBuL)@hqN`OF:Rr=pO@llT?8al3~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2104
+>>
+stream
+GauHLD/\/e&H88.EF/o0[:<DoQE4ODi251CMku8]m6cDTQ=ubq/?'m02a`)mNg)rRN[8=U0r:i`nouh6*Uf#q@#R=9r]f0>]Uct(-OVIEk"Dr6TaUJdE&59(Hr8/lH=B",Q4ledr8T:r@[6j<'71Q!*]V!_KD?:/mNp(A_>KR%o+BYUK\dPnAET\/*$+@mI9'is'o1142CbN!CY:jp#e)q@;F)Oph>@G0LMJ5N.!&.7`,(^s`/_qsbj=#SoE4pGe9e1m!Z%u(Do")C[D%O_,E3j?[oo0H7)C1D].SBs,T$_Xh@I)c/lTJ1;UXcpE7,rf[Od-Ad_UM!cnAZYd;&<WN]__<T;/_G,O/>goY(B3VhrL(Pf%=69Z6+0[9@tmUGlPs2+^g_*d[%3LWa=@kc[Jlm;ZhI_.E<KY%*3M`Ti*K%mAE0nhc(bgf#Y3\h-Jaa:t7nar`&kI#O`Pg4nG(YrDaG(fBnRL]D+ge+oLZfN5etcpHLd9_elPrL?e0^DlLATMa%)Dc$;[,-]IpgO'ShZ%`kKh?_YY_4kjZIF>.eIJDh/f)>4!E"J&_Npm<A5#f?o64#F'd%nM<3,_m;#>5]bD`!<VPi7oq-ApEuUdH*eQe6X+kEd_^O7<A#GfMep#?;:"'!VK6Knd-KBn@dD98+K=3YI8!=!9RMgOZ47UK:G.BjlH?Z<m+7q4HX8d&(S0=Y\J#B08nT\BfiMWYd.(]HH1q^N)O.S;J=-5NhDK+)S%$!ld:!=Y>OhYX@O@SF2t-33I*5"i%1UY^BHp[mfVZ$i<ir3`t6gVbbGq)<LGR[I/+'!.pN=(^B4<O<amjLW[W!aU]Y`l]a4$1k8#Tl!dAFG`RY+OMrK=MG'fbV+,CQ>>Vl*Qrq5*fIQ)e=gNlh/WCG=h%mH,:c8M$C*Bf^Z]GMGO]-h%P[Fk71WcTZ'^SO$_,]MVf'Me04)KO1cn26Ii\>pdZi,:,;2'(u4f,b?8^Ju6Rqn:$n#/ceCdPM%VK7*f@7d`0PnlSn]8F>=^U!eJ8T>?0S9,^N2P[8T=/sfhW*[El\8FgsphH"g45@tHY/S:i\%`pKCtS(afGs3nf^>bqm_c5"7)'_Z9LoR-!M&Lu)(WL,j=J;H6.H!d+=P%THDF1GH4V#2a'p=98rU28@`2Y$T/%lMhhSbr.c#>PBAfU\mPu;,=i]KA:8@JJogLE7+^23]pE.;2Vn!/7SSAed/5*Ot'>:6HK0TR'84T3W\cU23NFT&Q6M4TX',B9rc]4a.o,tnZfU`[Df2W0j0/C[)<1"6-g3=`t1ZC])-.bPZm7C7WpG\!7#,1SuA3<[jR8>@HmQX.B&L$<&DWG'cCuco`aAm'&5]3cEhO26+%)=o0KlmWo^a-0%!$209=J[eDUq%ocQZ9USD(4_,CT[bl>b2\#,gYu`K?3!UmtT*pc7:a^]Mmp1RmqX+a*s'qCeNc=Wdn.WC@t+>/mAKh8@hV6KjinCQL=jgK<^ChDsU9m*CupG-gHf^@r],dEKJ'.e\uLoiT%i7]?jl`)jGK[$A+"0*a"G,\?L1@8Bb*D72p@"fKl2gm;:/!rQ&tfa)Qi.`qO2m6OMHMU+bT=Z)EMc^&o;-*L^/,EEU\i:A^Tn)X7idDlCV:"EhL[g.H0g0R7/s_bHK;/DP.JT%d_A@@qY3d">_(dARDQbOe.4/'=ITTBU&jTi!Sa'Np/!&7)1Y.RME9/5KRJ245.Y?Je_h8bQ-5*U&A25LDOL[qKR.kt6g^:0gF?c^)O(,T3SmX-),%I#5(O@U#mb/L[WZ[RY1L:P+a1h+mma:P=7l2KqjFI7@(n''or2.bUem@FF+[\%G/q]k&dq(CD$@j/-q/eBTO"s8DiJTW)%_!t3Wf]+3A-VoD!RU+ZBQEH*X^#r@WBdbZWDrT75m4hU1#cYi(h1pj3?m=B!F&>#]\Gd?Q*Db5:c%bmuidEWJ/@r_T]%I!HQl(+T4ol'X&l!cW[-JfHCo@1#bhnf%TVs1gc08B0'Fs]e!b;??8A%:.Np#uD-\3X->+'W[:?9O>+Apc_Ca76b[%r+!gc,I0:."53l'A&3&B/Su(!hG(YL:BiZ:oPK%C[Kb<@]Uo6YA33prdfuW!W0R'RK~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1721
+>>
+stream
+Gau0C>BALf'RnB33%pl_"p72B_4A[VTuf[BD5^/VIUL0%U]o=?>'Y;q-,71Wlq6&2j@!_&*Y7,Ng%1cXG<S-&iK%XO"u3pj#rFkmi3cuK#HuV?^uQ7p9]!Fpa`dr4UXeSk)gK6uWWaF5EdQV[].k/p^`PCZ0SuLS]nFK`9R`j#J"jL5@'9acBWcukj(cc?*h-n1LFb8H[a?8q\p_3AD8:rr&^2K1d7;b`m.^@iDmf%ApN$-PN0RY+O=QF79JR??A-"4f@CY6P_<4f(\AYce1+@>H_bo]NGMVID00G,0f7i,YnS.^@"!cCpVXOX(UkN:t@?qI_7)TL$TgV/K^h,#>%Qp.P'p-aRaUJ1-^qqs17VIf!g-[t7VG\[/'<2+!9s6r!iKE2NVo;oF=i;8Uq"u+=;*QW?TUcn@^LO^&CYkJr\F/gfSr9%e2JB_@l"h+C_?Vlo3W+#D$e&9-@j[B',tN_/ThlTa_jo_cEk#Fe\Esp=?=gXa%hG>CQI2.:S*'l-e!a-<BJqb2MQU!:ga#T`]2o%$2P.<Ml?">'3Hil1"fpm!.JW>(13ig]pmorMi7BLm+Z"p\#>6*oG`.Pq\=0b>-=,Y`k!>ktfg<ml_o&Pqk&k7&SJ%=A56On1+oe#sg(%s<[]l;10jEarh[r4(F<Ii:WHW4HLI`MKb")YelVcpe^[I]*(b:U\&i4$B3+e&=@kXW2hmr,A^N#gjLp$FJl00YZBL<aN%"HBD'(B63>::9UecA['lkG8?@J,Y3koBku3V,LK-o09**FB)3V*;RTF7tX>g6T6iXg0aO+!+e&HhVI]j%oE:o!R(#@]@bdD4*nOj("s\UGj7`g>,J3oXOS.lEm;-_!]jo,@bq!c3\842knq/\a"$/j@&KpVc&or-h,h3Pc[K(iJ/`-N-QfgQu1"=0/1R;'Y6n'r\k1biQ)KI)W*fljhXK-CanqJLr?%olhO3[X<We[0U(`'#ak&OUV?=<`LRseD>5[4$Hj5UD6g+X9SB,<^c!%)\f8dOd$FGmcKAchm8mqhK2K;@4EV;pF!I#6#UIER"lpj3R-G;Ic&=`CN>lF%-uHAIV(Ln4B:k?<l;qVjO\BkOI;DhIj)dZaOD:[Z&3G%WZXRBIRq:Q1Rl]?^%dR5u0,`'f0X&T"k)8-q5DH6=RK=ue?DKiV.iJI_ZQ1m,-\jSP<\\ZpAWa<8S`Ee5B!Y$A]$1kL.5c"/i#F5-6?P^s11gD+=&^*eBekrM$R2':E&\J/Aqr%U[2iC6@+p84pOi&AY79*Sfa94`.4>8[k3,8[$+4c8k+=JZjE%J'/tMb-_LeZ/;T;Rf(G#PUY#&.nCVP:h+Fb?@j%+J=a;_-A:q]Wc5b7el7=cr4<X@38#TTIV=8rsHVk^"=,*'4b38g5D^L3/EhYhA3Ur4)YMHPTYUG1m47n2=\TKpM2`*N,qnAZ"Yh/m/(1fdpun=?Q_A^5e/>"2P('LB$pn@EdgYHV!U=lj\"KQ;VuX\m=2\QU(]bV,#PP`-o(43$=1TTV8Wl`[)mhYWkrmXX8.gHE))%YVgCc1/W.H_*TQJPVI7W#dYcE,ji?6q38-/E*O#U[<W3n^WKj`&)fSF`^:[gs23!kOIDbUe;)M6p`9LV.`sDE:mM'52%VP1,O#R.)&3*N$6Nk;C_4UC7gtN)ro]k11HVW6'f+N-d@'>J"('8qpcsUO2YO$`+,e_l8R4OR;qfF3HNVCnE(h="kG^~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 806
+>>
+stream
+GatU0?#SFN'RfGR\1a-26phS0PWi&U[!S7k9[*YM8?;&]W7s:,D24/MqHZ0+K1[hs'48cRq"gN@'1WV^/+VS&!dr7#n1B5?L27%@-l>8D*U^5>\$NLuon>*0C(#].hKnQ3;;6"ONe?RQJ`/FV+Ht/F/g,Llm#,*>KA,^C8I1M6V"J!@D!5LB>L@'rN*R+C/9GCBbn90q5J82K@Y<;%MHGF/-#WUQC<Ml1fUs!1_3l%<liSbZcreiLrs)E<ltujmc_<[dU(gN'(?HIEWiNuGXFa'FNQ=ucf_7dJ;4"@<_1A6iP*.)),jkL<4m0=4m>/ucG:GZ5eE#n5gJ9eo[S"?b:Jt9sN.f?R5jnm0U9pbh'l#;1=9"6KY4V$UOaH7jjcHPl[_=SVB:UK;)$_+"7IL)Z1d(0NkS*B/?+p#d3MV(k1Har^Mnt,_,%h\92)lJBED$=W7EWlH:Zsnl3VGNr*88o*N2=?_B^*EW>(?HarPK<Fj8[PG[90V0)lVCi@VPe/f9NguMRB]3O[/hdnjh0=@<%l:R$=qp@\,@"N^]6h4)B-Ni@:5%pWM2&H[L2dB-e4:QSjD6[6&qD_:G'sDB=VD[XsEp&c!-.JM-N"2$l<q>WAN8@+fllCC>7DQPW0=F,-@U:Agc'MbYpDDALichETBGDPD^HRL\$k+`5an=T,ouq1jbg44nmGh<'(?g5PEC+=`Q=mIC>:r4IsL?B=nn6R`L48):;f*!U@4%,HW)J(TdCF!=3k(BqBAqeZbq'H!u0*iu&(C"'e90IM/b3Jtsb"abRZ3"N:sB7BpTS&0m~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1822
+>>
+stream
+Gat=+D3*C?&H88.0sXc8X2&+L%ocOQVaP5u2:imI/)?cC@Lm(gg?\+.iOC<9]sDKj9H'G`NYC@,fpUN+hAua^d492)@05qE!St3c"FXCR+W1&C=SrYI(9]p83po\t7aJh5DNI9VY@9!p*;,:\I=F9u_dMbj@?EfjEWqA^YkZnCq30<nK&[nG8DTB/(Ij#!US0gf3()N2IIbCHm^\[ATf)OProP<t`@5\IIYE&s%LL<6T#M>8@9i"PUL0E0?]RjdV:';7GErUn`mteY)o+PGGII06jrsk\R6ln4JP=0+O&.\Q*aCWC*X)J@YT6iE7n"u!opSltUd?aSKR$8"DjZDiLMFd::Z.qc2#.k1hdQ.reV6cY)Ao8J,u!f@N3'3)0f3.44tK7Jl+(oMFgRBK[,?+*;S>G"Etj`@SVJ.lp+smf1)MTgC/D$8Lq4%AbCuTb_d_H)'LoTE\M,:sj^sq%#^*U]PI[Y.gV?^u+bmPek!0aYP]MNb>uUW[d(5J?iL&K`EK&VAJH@mf@)<1@Mn-H'b/D1tPPJX:l;+PXT5GCH/_#N>hD3&&\.ah![Z[^b"1\%Pa5S!tY<H$l!I/0f/U?F%MT9;T+*d1a&@74t$n2jU\Iqq\@n`b4h/7Mna![0`!k\FQL$3>O\PKj*=N;KS5AHUXl_K_6L/KQO[l!&Q[0D*KCEZrX;Y;"P\bZKpRT;P1W(=%fpNI_Yq!7Y99H/h;c[45Uh-Jsh%XgA/VoV&B-Gh-.FFU1dZY)#b<`3h%CVf%jn_.<l&ouZPl^kr\=V'8Yc!PC4mhs)f-to=0H>Ir9/9W64A@e1:4LL[OFLJg2Qimqf9s(Qcq=.,&X2f;UO,<mD%$-[HQRk'7g,:G$YHW(nCMgr%pDTGd7:(J2PC287]SK\21:H1o)t&`8p9[]<Os3TF$3`-8Rq4&Y?QUqq:O@2-9_EDmScY;)(d?2$)C&MGc7!#,.t>)l%u.b`;+3_'R/:jcipN6?eR#bjUHh`mVhTtd4aA^f$Cg,WloE>hj-7/P]i-lDJdYYJ>bBMP\k4Zef]mAi:RF2Y(([aG`Ojn#4JI:!Yq`Djg(%q(pF`6V)T?^:"SH>-LHp7nf(nq/i<77ibDh.[XK%p=1c6LifY^^!QQ6J]0*\K7!*6)m"^p.$6O4<`39ur!L(I68;UnZ4d]f`WhQH#JWcG+-i9IgV'J-bG"W#QQD2L(!&P0<:Td6TN.dj0u,j<dMdsO8QZ0(R5-o:`(^^V34qd.)q!*<^Z2^b_%/On2q:e.,Y?_<Df=\<N21c5<I5*/SEA^PnZa-8.'$[>Zt/UIo*a7>M27]?1Dl&25R?A>IXqZ<_Y;.Ng:7qW[m('nK^fQpFX[)lmc8$jF/)(V"i%W)9,-5L6.L_!QP3Mm+G'5I\?gPc9DP<>jQb+oTZYmQ>32<-M5]rY?Hi'sSC+!L:h\OGL>oO'@:cu"Rub(OdXZJ;_,H8,:mao4LSbI,WXdYJs0km5I8M*^\lV2Pc-]qf1MH\WJ7YTU*f#.OQTZ#D`lohH'"E)qh-hcS!bVAs[@\iA'_#/g)a.O-5l&DD;%(XS&egE;3Y=:eN31U7>YgYZgk-H!54>1p2Kk]kh4;(.Ngq_X&(im2Li'$\MHaEDEh\j[B"Q!A[8[NLiH4cPDEoRi*d&q"YTEP=e0p1?0g^dL;;2g>5J\@+rqFU%=7?Be*#q1a]$U?cG@Wl3kP"k7f9bG3aIc'F$c/tqkO8X(n]$Vj?RXX7M^Td:=mh^6t(qJM9Bf9u2t":oL?n5)s^\03g.URqFb]+N0o/X7K^3?p_aaUt7'Bgce&Cru4C'=2^FJlhsR91D`1~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 659
+>>
+stream
+Gat$s@;hVh&H/2-EJcT0:(,#aOG"..d]Si^og;e8Bi7kYN]@_2?rPgeq=ufV/>69+/Hd?g]6j#&4T^2JLjQE?i$sH(>68=DBb"\5:E[?'Rrn-TBM[dY+Rj%2JOLRXC=>F=gFnH(rd5bS3;6oR9CQO0O?Q&.Z)RP2gNC:kJ8$^ForK-\\6#%j<Dm<\];LMr!f-'M[eJDbS#2O]+jBjuX!h]sGlY@X&g1*c*.Ap34aAqJJRMjUCj98\4<k(g05&ob#O6:fUtG4W[V.C%=E]<`F"&qJ.o9-O6W4_a+ll0gX\ec%hm8)Ha5/$M8`R"].r!YkMO`]H3g&>XoSX.c"4pL`)Aj3N+Y0KXW0B-%al68A(LX\mPm(31bmSDKC*+3M5MFPU$Npgjcujp/rS_OiHkc?A7-kE?^_=(C>rdE'r,/@dktg_'mV,f=R"4M\L=aTBC*aLMqa@26"dW2<nk**<dA7(@c['it)(MQ0^1=Vt3L4gI![e?pW*m-J!6]k`G0R@PMp4IHF^8!F)/Z:FC=_`+"'Z.g]^"U4s0oC*n`9]o*_jpMI'm.CBNsum=17]e^9K7i#4<O-!l&u%H"c3qpQg2#_%VbsTAf'Tq"m=2:T(<7meVb*mHY;001RFS_C3RNaN,BZ52;Uk%1WS,!N,*Hrr~>endstream
+endobj
+27 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1491
+>>
+stream
+Gau0BgJ/t`&:N^ll>97+N5o!.:LofW=@Lmgp1EoHK\A4FSdmp>6XKiVlVl>T1$lp)@O]/L[\p_iVbWe_"GZ]<K_MhVpj!%@*tq17Yf\,W$mr4T"g1lrpIEJl7<gL+S2CiH7/\k[3g)>nVUNq#Z'`@P0poeWK\k]*<e&$P-bAn2RVNGZL+l,='D.="%`>J'9atMt(/@)S0VI>eq!QB3YiMcB_JT2.N45r#9P(HU&)8S1;Z=Pp2bn!uZQF<n@khbh-En1'`A>$ZE96"@1RS]$KlVQ.d6ufNcf/i_a^A;!:'fur?&.A8Ec_W==-Y\hU:4+u9W/DJ>(6Gc^@HE&M`G^cKq$qsYKNDFd->nD"1Z#?$Z)NMbQ'pAq%i>bdUU*n)ged*?g&\FVCO%$@T%*[n9Zes#?UC-Ec%H\S)P]d%o.(r5$!BQn1:AkKh.U7OU&YrPMqq6cA8lP'R@jLU'7iD>Qa7JUfpo.P0#,F8HWYLggNHaeBmg%5n41pP!,&"TC&`J/^rQ+/Y,@YE\HMa>HlmKDKK%E8gt6n^dn!cSk\(5?a9qDNqOjQRGF3;1>eS[T/C\W"3DG3>q>n*<OQ=&=X"=uA+\f<`0+Vqml6J)H]rJ\-\B-.AVB/ABdqI^EcoWJ6EWYBFJ&kc7Rm>!12_m`mfIJ4cecW\RiR#`c&6QE[b3187<mccc7o&Tr01&OJTV5:ap5Xq$*/WqSl+!H:bm+4>p\apQg<,Dhlc!2:OZD;?]*PCY+?V7ff-3+%DH7M4m^pfF>YOce);gG)BfiP>MtFYAhiKuBL#L@7&M;JADAm_0cUs\9JOV]>/37pV+>JXfNRE8,bVWB<.[ed>\XreFqd'XpBS?5>K+J`;S,dtV=EVFV(MAEZD_FIputOEB`Z$nbr8TT`3.O?DHD:HKU1A+TdKBY_-J(DXj686"o,1M)Y(bc4,9?<Zj6f9Z`0)\l35BJ,jan\]&aBND?G^(i;s$u4R_b*F]E+92jQ&gHe[X0XJ1bTB(Qn[EI%VFe(;OCZhjAJ^W*(@>1=UT%1T]`b#ht)KAYea!\&chKmh4oPZpf@c5DUSOF6dD3t:@ealD'8&'dA5ELkXhBE(8QL;C-6f4D\^%+I--8EIjZ=5e,=Q,>+D\J*HGEDNYZN]HItGkT$VB(S9l)rof=d!SD'_MN;jb+O@/<?>X&n;B\,`nZX<Zi?eS40o1!n->Nm'uWuu;3EE:a]VlU8p3tNH\o)^3.\sQC\$SJCO95=>B&=-KYrXG<jr$;mir9!fa1Q#\(p\EF**dE`&F(RjD_5Z1hgUr!2,Y&$u"pCcZe`NYsGLJ\`*RoP+4;?kXGn2_"<RsR:st3:o4]j]:J&8QG8`&A782R9X688)bpqG<J8o6@NnSBnaM'/[fJ84n)N$r-j&IVKIn`eU"e&`q(p1D!u/'nEGB.1Z'/E07.-r(o$-Zo)`heRNr)+&_V/8"Xjeo>"1:6R)]BI6.Or=o9Eo@P5Mp5Z*;p8oFoZ@~>endstream
+endobj
+28 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1307
+>>
+stream
+Gau1.D/\/e&BE\k;r"Fi)/S!3jei=#i3i""-_O+4F>![u1j-6p:_H,n:AjL'Ugu=m)S+6R,S25Y3o9g[pZFPi!W@`Ob#<gT@d(Q9+WNh]L+irYLd/a35.`nWhTYqV5qo?Gd#@O&DqpS]Z8[f@_0eG"d6*d]S3eSCS3qZ+nZVAU^W>8?k%"HjZ5:pZ1ck-$a0l0`3>;A#6h8;OmhbH:!dL%]M(*&&=cm?i,g5,G,;QFF;0d;5[-X!1-aUq@/mJIG<""KN8OtZrc]I;^?nkpYGb-C*@jM^DDM59@%kGY<=#?o(M92i@ikU$$QPrnTJ*bgtK_c,+l0Q%4k<^*kj"`U'U:XcZ\eJH['c%a4IEcj8QY:EM6Oie,DBUHrlqt,o0SNE8[R?[saZWC_K,[1I@CMVT+8!l\k<U>HW&99;",3[2L!Q\,D'EY:s-No3&m,l8-D5I0KA>X\a:`kC"Qi`UBt@^*L9;709Wgfr;6Lj-2i>8p_X:4inAY,g*oYlV))VCSR([k;jg5.f#6,O\@3t+g+&m->!aqI8@Ia0L/,40WhX/0DZ.OndM#H`R>SDYFJtNOVo8CW#6>/1ljmt?p#-q3=IL]dj/H>,a\/#r/(N>;2%fU[2E4L2peTfpP<LGnqo;$-%02J,G'YAPq6ZK.hUISZN9&ght`l(FQe9M(%00f<_,*4_G\V(^Z'G5'iI/;='Gq<=?8+JM_q0JTE<\nX0k-qL,aUqR8\'DaJp=e6aa*@AD-s1?Zh^DSIfb`."6(iod"`X\j2O&+Kr`a1k5SYduba+ha(g,r>8EduqE$'As(5uFPhB6%1eJ>Gj<?cg9o)Z9J($\l)@o=Sr,4M@emR#&1h3N>R1$Nnqlh;JWi]t-bcP9?+'>(sn.5oW\>LR94XP2s_Be5F#oZGl;)`X&0*Q]"$U2l.FLT6K3:_lU_;4l_9BQiB/H*6F%O/d(c<>XtQc52h'9H*BA-Ju@^aEV44&08pm5:sA.PaIu6m)#u\`hV8X`Us-$Uf+ONEjIq^>it.u(RXiQlu:^l"67r4)N(]+g("*H=NW+V']8J3l\"KbaALSdrDbLFF*+2.d5;V8D7*Yk)HBWlfkI%No]]!%TUhAuThs2%m5gnl;jV!mCU2Rr8_8pi]9!:chkM8WELKC+eWW38+3dQZ^nHJXd=KN?@7feEj7Fj1Kg9&PauA#hf=rcDH^U.G\DP_.hhS`"W/Uu4n-D\3T$)'#:tHPq:%h(<9rRrSPpTee4mHlP8t'PDMH5=`CU*G'H&L2C^u]V,k0qbBFNje?ii`:TYUN,F8HbW*K!Tq,7b*#K~>endstream
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 766
+>>
+stream
+Gatn$9lnc;&;KZP'miUl/:T!\H:qsuJcU`>*-+p<[A2<]N23h3?dDoa>?Vq$(a^?"nZL_mpR.9d69q0irJM$@+pIurKJ8!7LG3-CV!h`USpWWa,:aQ9fNB;hN:*a)2C7__k/idg<Y<8#[Xb`:=W!_sH4/u,G11*P)_r31/4hK<H[6U?VpDaP86Q?".\_fj]ec:_(gLR2)JaodRJI<i`H'Aj&)@Ca-0e]Zh(r;YFWW&ZH1iM1XR'oJk$@)NB=lGp#?:T3^tQZf+EkCM&@Sq<k3M^T1cEKIX7UVoFU$Hep#UtRq,"qEB5M/(ID:ke\%c?<<PE4Pp@-G%Q5)t0T=;u8Uf/>R17s*92)L4\W6G9,,sDeb>/M_iX:hN9%m!1HdKjuV6tAA0\OC#;Vroaqi">^PILB)cn@KClW^_jH7Q*g4UH%8T38tMinc-Jr1!c\X]S%pI$;##NV5iK<?ni$YLi`s;q/t:KL`i.6>`o[3KC"i_nf5X/1;dAJdWK*=%P(:AigPAO:!Yo(1WUl.R<]0bYZMjeV6uFSc0\i4TkXAjHl\]V-Ta+VE5"<$9Q5HNi1oYR'>.@.X*E+QicYS*23_lFS(Rn0V0?"ALUoQ4m+0OV=nPD.'1CKls+[<:grC;Pa^g-a&Vbr)'S[A&5p.d6dn8Eg';dUpG89)eqqBIE%)lObSDHg?(D"/n8d(Es$XA4)egO*+gtklk20tZ'L@GNF3F@!dhfR_H;\S6j1n+0@0D^)3*jK?>>EpiY_oY\>q[e&~>endstream
+endobj
+xref
+0 30
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000538 00000 n 
+0000000733 00000 n 
+0000000928 00000 n 
+0000001033 00000 n 
+0000001228 00000 n 
+0000001423 00000 n 
+0000001619 00000 n 
+0000001815 00000 n 
+0000002011 00000 n 
+0000002207 00000 n 
+0000002403 00000 n 
+0000002599 00000 n 
+0000002669 00000 n 
+0000003009 00000 n 
+0000003139 00000 n 
+0000004935 00000 n 
+0000006516 00000 n 
+0000007798 00000 n 
+0000009994 00000 n 
+0000011807 00000 n 
+0000012704 00000 n 
+0000014618 00000 n 
+0000015368 00000 n 
+0000016951 00000 n 
+0000018350 00000 n 
+trailer
+<<
+/ID 
+[<34681c22749e442c67c43065f6737183><34681c22749e442c67c43065f6737183>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 17 0 R
+/Root 16 0 R
+/Size 30
+>>
+startxref
+19207
+%%EOF

--- a/documents/a2a-integration/callflows/01_provider_onboarding_sequence.puml
+++ b/documents/a2a-integration/callflows/01_provider_onboarding_sequence.puml
@@ -1,0 +1,39 @@
+@startuml
+title AEX ↔ A2A Provider Onboarding (Agent Card Ingestion)
+
+actor "Provider Admin" as Admin
+participant "AEX API Gateway" as GW
+participant "Provider Registry" as PR
+participant "Card Ingestor/Validator" as CI
+participant "A2A Server" as A2AS
+database "Discovery Index" as IDX
+
+Admin -> GW: POST /v1/providers\n{ agentCardUrl | domain }
+GW -> PR: createProvider(pending)
+
+PR -> CI: enqueue(Fetch+Validate, providerId)
+
+note right of CI
+Fetch order (compatibility):
+1) /.well-known/agent-card.json  (latest A2A)
+2) /.well-known/agent.json       (older A2A)
+end note
+
+CI -> A2AS: GET /.well-known/agent-card.json
+alt 200 OK
+  A2AS --> CI: AgentCard JSON
+else 404/Not Found
+  CI -> A2AS: GET /.well-known/agent.json
+  A2AS --> CI: AgentCard JSON
+end
+
+CI -> CI: Validate schema\n- supportedInterfaces\n- skills/tags\n- security schemes
+CI -> CI: Verify signatures if present\n(RFC 8785 canonicalization + JWS)
+
+CI -> IDX: upsert(providerId, skills, tags,\ninterfaces, extensions, trustHints)
+CI -> PR: markActive(providerId, cardHash,\nsignatureStatus, fetchedAt)
+
+PR --> GW: 201 Created\n(providerId, validationStatus)
+GW --> Admin: providerId + status + next actions
+
+@enduml

--- a/documents/a2a-integration/callflows/02_work_bidding_award_sequence.puml
+++ b/documents/a2a-integration/callflows/02_work_bidding_award_sequence.puml
@@ -1,0 +1,39 @@
+@startuml
+title AEX Work → Broadcast → Bids → Award (AEX exits path after award)
+
+actor "Consumer Agent" as C
+participant "AEX Work API" as AEX
+database "Discovery Index" as IDX
+participant "Provider A2A Agent #1" as P1
+participant "Provider A2A Agent #2" as P2
+participant "Bid Evaluator" as BE
+participant "Contract Engine" as CE
+
+C -> AEX: POST /v1/work\n{requiredSkills, constraints, budget}
+AEX -> IDX: search(requiredSkills, constraints)
+IDX --> AEX: candidate providers + AgentCard pointers
+
+par Broadcast WorkOpportunity
+  AEX -> P1: WorkOpportunity(workId, reqs, bidDeadline)
+  AEX -> P2: WorkOpportunity(workId, reqs, bidDeadline)
+end
+
+par Provider bids
+  P1 --> AEX: POST /v1/bids\n{workId, price, terms, confidence}
+  P2 --> AEX: POST /v1/bids\n{workId, price, terms, confidence}
+end
+
+AEX -> BE: evaluate(bids, trust, fit)
+BE --> AEX: winningBid(providerId)
+
+AEX -> CE: createContract(workId, providerId, terms)
+CE --> AEX: contractId + awardToken
+
+AEX -> P1: Award(contractId, settlementTerms, awardToken)
+AEX --> C: AwardResult\n{contractId, winnerAgentCard, awardToken}
+
+note over C,P1
+Direct execution is A2A-to-A2A.\nAEX is no longer on the data path.\nAEX re-enters for settlement/trust updates.
+end note
+
+@enduml

--- a/documents/a2a-integration/callflows/03_execution_settlement_sequence.puml
+++ b/documents/a2a-integration/callflows/03_execution_settlement_sequence.puml
@@ -1,0 +1,33 @@
+@startuml
+title Direct A2A Execution + Completion Receipt + Settlement
+
+actor "Consumer Agent" as C
+participant "Provider A2A Server" as P
+participant "AEX Settlement API" as S
+participant "AEX Trust Broker" as T
+
+== Direct A2A task execution ==
+C -> P: A2A JSON-RPC\nmessage/send or task/create\n(+awardToken)
+alt Streaming enabled
+  P --> C: stream task status + artifact chunks
+else Push notifications enabled
+  C -> P: register webhook URL
+  P --> C: POST webhook updates
+end
+
+P --> C: Final artifacts + TASK_COMPLETED
+
+== Completion receipt & settlement ==
+P -> S: POST /v1/contracts/{id}/complete\n{receiptHash, evidence, signatures?}
+S -> C: (optional) verify/ack receipt
+C --> S: verified | rejected
+
+alt Verified
+  S -> P: settlement=paid
+  S -> T: updateTrust(providerId, outcome=success,\nSLA/latency metrics)
+else Rejected / dispute
+  S -> P: settlement=withheld\n(dispute workflow)
+  S -> T: updateTrust(providerId, outcome=failed)
+end
+
+@enduml

--- a/documents/a2a-integration/callflows/04_architecture_component.puml
+++ b/documents/a2a-integration/callflows/04_architecture_component.puml
@@ -1,0 +1,52 @@
+@startuml
+title AEX as A2A-Native Marketplace (Component View)
+left to right direction
+skinparam componentStyle rectangle
+
+actor "Consumer Agent" as C
+actor "Provider Admin" as A
+component "Provider A2A Server" as P
+
+package "Agent Exchange (AEX)" {
+  component "API Gateway" as GW
+  component "Identity & Auth" as ID
+  component "Provider Registry" as PR
+  component "Agent Card Ingestor\n+ Validator" as CI
+  component "Discovery Index" as DI
+  component "Work Publisher" as WP
+  component "Bid Gateway" as BG
+  component "Bid Evaluator" as BE
+  component "Contract Engine" as CE
+  component "Settlement" as ST
+  component "Trust Broker" as TB
+  queue "Event Bus" as EVT
+  database "State Store" as DB
+}
+
+A --> GW : register provider
+GW --> ID
+GW --> PR
+PR --> CI
+CI --> DI
+CI --> DB
+
+C --> GW : publish work / discover
+GW --> WP
+WP --> DI
+WP --> EVT
+BG --> EVT
+BE --> EVT
+CE --> EVT
+ST --> EVT
+TB --> EVT
+
+BG --> DB
+BE --> DB
+CE --> DB
+ST --> DB
+TB --> DB
+
+' Direct A2A after award
+C ..> P : Direct A2A JSON-RPC\n(after award)
+
+@enduml

--- a/documents/a2a-integration/callflows/05_end_to_end_activity.puml
+++ b/documents/a2a-integration/callflows/05_end_to_end_activity.puml
@@ -1,0 +1,48 @@
+@startuml
+title End-to-End Workflow (Activity, Swimlanes)
+
+start
+
+partition "Provider" {
+  :Expose Agent Card\n/.well-known/agent-card.json\n(or legacy /.well-known/agent.json);
+  :Register Agent Card URL\nwith AEX;
+}
+
+partition "AEX" {
+  :Fetch Agent Card;\nValidate schema + interfaces;\nVerify signature if present;
+  :Index skills/tags/capabilities;
+}
+
+partition "Consumer" {
+  :Publish Work to AEX\n(requiredSkills, constraints, budget);
+}
+
+partition "AEX" {
+  :Match providers using index;
+  :Broadcast WorkOpportunity;
+  :Collect bids;
+  :Evaluate (price, trust, fit);
+  :Award contract;\nReturn winner Agent Card + award token;
+}
+
+partition "Consumer" {
+  :Connect to provider directly via A2A;\nStart task (JSON-RPC);
+}
+
+partition "Provider" {
+  :Execute task;\nEmit streaming/push updates;
+  :Return artifacts + completion;
+}
+
+partition "AEX" {
+  :Provider submits completion receipt;
+  :Optional consumer verify/ack;
+  if (Verified?) then (yes)
+    :Settle payment;\nUpdate trust = success;
+  else (no)
+    :Withhold / dispute;\nUpdate trust = failed;
+  endif
+}
+
+stop
+@enduml

--- a/documents/a2a-integration/callflows/README.txt
+++ b/documents/a2a-integration/callflows/README.txt
@@ -1,0 +1,15 @@
+AEX ↔ A2A PlantUML Diagrams
+
+Files
+- 01_provider_onboarding_sequence.puml
+- 02_work_bidding_award_sequence.puml
+- 03_execution_settlement_sequence.puml
+- 04_architecture_component.puml
+- 05_end_to_end_activity.puml
+
+Render (examples)
+1) PlantUML Server:
+   plantuml -tpng 01_provider_onboarding_sequence.puml
+
+2) Docker:
+   docker run --rm -v "$PWD":/work -w /work plantuml/plantuml -tpng 01_provider_onboarding_sequence.puml

--- a/documents/a2a-integration/diagrams/01-provider-onboarding.puml
+++ b/documents/a2a-integration/diagrams/01-provider-onboarding.puml
@@ -1,0 +1,88 @@
+@startuml Provider_Onboarding_AgentCard
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 1. Provider Onboarding - Agent Card Ingestion
+
+actor "Provider Admin" as admin
+participant "Provider Agent\n(A2A Server)" as agent #LightPink
+participant "AEX Gateway\n:8080" as gw #LightYellow
+participant "AEX Provider Registry\n:8085" as pr #LightYellow
+participant "Agent Card\nResolver" as acr #LightGreen
+database "MongoDB\n(providers)" as db #LightBlue
+
+== Provider Agent Setup ==
+
+admin -> agent : Deploy agent with\nAgent Card config
+activate agent
+agent -> agent : Start A2A JSON-RPC server
+agent -> agent : Serve /.well-known/agent-card.json
+deactivate agent
+
+== Registration with AEX ==
+
+admin -> gw : POST /v1/providers\n{"agent_base_url": "https://legal-agent.example"}
+activate gw
+gw -> pr : Forward registration request
+activate pr
+
+pr -> acr : FetchAgentCard(baseURL)
+activate acr
+
+acr -> agent : GET /.well-known/agent-card.json
+activate agent
+agent --> acr : 200 OK\n(Agent Card JSON)
+deactivate agent
+
+note right of acr
+  Agent Card contains:
+  - name, description
+  - supported_interfaces
+  - skills (id, name, tags)
+  - capabilities
+  - security_schemes
+end note
+
+acr -> acr : Validate schema
+acr -> acr : Parse skills & tags
+acr --> pr : AgentCard + ValidationResult
+deactivate acr
+
+pr -> pr : Create AgentCardProjection\n(indexed skills/tags)
+pr -> pr : Generate provider_id
+
+pr -> db : Insert provider document
+activate db
+note right of db
+  Document includes:
+  - provider_id
+  - agent_card_url
+  - agent_card_raw (full JSON)
+  - skills_index[]
+  - capabilities
+  - trust_score: 0.3 (default)
+  - trust_tier: "UNVERIFIED"
+  - status: "ACTIVE"
+end note
+db --> pr : Inserted
+deactivate db
+
+pr --> gw : 201 Created\n{provider_id, verification_status}
+deactivate pr
+gw --> admin : Registration response
+deactivate gw
+
+== Agent Card Refresh (Background) ==
+
+loop Every 1 hour
+    pr -> acr : RefreshAgentCard(provider_id)
+    acr -> agent : GET /.well-known/agent-card.json
+    agent --> acr : Agent Card
+    acr -> pr : Updated card
+    pr -> db : Update skills_index if changed
+end
+
+@enduml

--- a/documents/a2a-integration/diagrams/02-work-submission-discovery.puml
+++ b/documents/a2a-integration/diagrams/02-work-submission-discovery.puml
@@ -1,0 +1,83 @@
+@startuml Work_Submission_Discovery
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 2. Work Submission & Agent Discovery
+
+participant "Orchestrator Agent\n(Consumer)" as orch #LightGreen
+participant "AEX Gateway\n:8080" as gw #LightYellow
+participant "AEX Work Publisher\n:8081" as wp #LightYellow
+participant "AEX Provider Registry\n:8085" as pr #LightYellow
+database "MongoDB" as db #LightBlue
+participant "Legal Agent A" as la #LightPink
+participant "Legal Agent B" as lb #LightPink
+
+== Work Submission ==
+
+orch -> gw : POST /v1/work\n{\n  "category": "legal",\n  "description": "Review partnership contract",\n  "budget": {"max_price": 50.00},\n  "required_skills": ["contract_review"],\n  "constraints": {"max_latency_ms": 30000},\n  "bid_window_seconds": 30\n}
+activate gw
+
+gw -> gw : Authenticate (API Key / JWT)
+gw -> wp : Forward work request
+activate wp
+
+wp -> wp : Generate work_id
+wp -> wp : Set state = "OPEN"
+wp -> wp : Calculate bid_window_end
+
+wp -> db : Insert work_spec
+activate db
+db --> wp : Inserted
+deactivate db
+
+== Agent Discovery by Skills ==
+
+wp -> pr : GET /internal/v1/providers/subscribed\n?category=legal&skill=contract_review
+activate pr
+
+pr -> db : Query providers by skills_index
+activate db
+note right of db
+  Query:
+  skills_index.tags contains "contract_review"
+  OR skills_index.id = "contract_review"
+  AND status = "ACTIVE"
+end note
+db --> pr : Matching providers
+deactivate db
+
+pr --> wp : [\n  {provider_id: "prov_A", endpoint: "...", webhook: "..."},\n  {provider_id: "prov_B", endpoint: "...", webhook: "..."}\n]
+deactivate pr
+
+== Notify Providers (Webhook) ==
+
+wp -> la : POST /webhooks/opportunities\n{"work_id": "work_xyz", "category": "legal", ...}
+activate la
+la --> wp : 200 OK (will bid)
+deactivate la
+
+wp -> lb : POST /webhooks/opportunities\n{"work_id": "work_xyz", "category": "legal", ...}
+activate lb
+lb --> wp : 200 OK (will bid)
+deactivate lb
+
+== Publish Event ==
+
+wp -> wp : Publish event:\n"work.submitted"
+
+wp --> gw : 201 Created\n{\n  work_id,\n  state: "OPEN",\n  bid_window_end,\n  providers_notified: 2\n}
+deactivate wp
+
+gw --> orch : Work submission response
+deactivate gw
+
+note over orch
+  Orchestrator now waits for
+  bid window to close or
+  polls for bid results
+end note
+
+@enduml

--- a/documents/a2a-integration/diagrams/03-bidding-evaluation.puml
+++ b/documents/a2a-integration/diagrams/03-bidding-evaluation.puml
@@ -1,0 +1,116 @@
+@startuml Bidding_Evaluation
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 3. Bidding & Evaluation
+
+participant "Legal Agent A\n(Claude)" as la #LightPink
+participant "Legal Agent B\n(Gemini)" as lb #LightPink
+participant "AEX Gateway\n:8080" as gw #LightYellow
+participant "AEX Bid Gateway\n:8082" as bg #LightYellow
+participant "AEX Work Publisher\n:8081" as wp #LightYellow
+participant "AEX Bid Evaluator\n:8083" as be #LightYellow
+participant "AEX Trust Broker\n:8086" as tb #LightYellow
+database "MongoDB" as db #LightBlue
+
+== Providers Submit Bids ==
+
+la -> gw : POST /v1/bids\n{\n  "work_id": "work_xyz",\n  "provider_id": "prov_A",\n  "price": 30.00,\n  "confidence": 0.95,\n  "estimated_duration_ms": 15000,\n  "sla": {"max_latency_ms": 20000},\n  "mvp_sample": "I will analyze key clauses..."\n}
+activate gw
+gw -> bg : Forward bid
+activate bg
+bg -> db : Store bid
+bg -> wp : POST /internal/work/{id}/bids\n{bid_id}
+activate wp
+wp -> wp : Increment bid_count
+wp --> bg : OK
+deactivate wp
+bg --> gw : 201 Created {bid_id}
+deactivate bg
+gw --> la : Bid accepted
+deactivate gw
+
+lb -> gw : POST /v1/bids\n{\n  "work_id": "work_xyz",\n  "provider_id": "prov_B",\n  "price": 25.00,\n  "confidence": 0.85,\n  "estimated_duration_ms": 25000,\n  "sla": {"max_latency_ms": 30000}\n}
+activate gw
+gw -> bg : Forward bid
+activate bg
+bg -> db : Store bid
+bg --> gw : 201 Created {bid_id}
+deactivate bg
+gw --> lb : Bid accepted
+deactivate gw
+
+== Bid Window Closes ==
+
+wp -> wp : Timer: bid_window_end reached
+wp -> wp : Set work state = "EVALUATING"
+wp -> wp : Publish event:\n"work.bid_window_closed"
+
+== Bid Evaluation ==
+
+wp -> be : POST /internal/evaluate\n{"work_id": "work_xyz", "strategy": "balanced"}
+activate be
+
+be -> bg : GET /internal/bids/work/{work_id}
+activate bg
+bg -> db : Query bids for work_id
+db --> bg : [Bid A, Bid B]
+bg --> be : Bids list
+deactivate bg
+
+be -> wp : GET /v1/work/{work_id}
+activate wp
+wp --> be : Work spec (budget, constraints)
+deactivate wp
+
+== Get Trust Scores ==
+
+be -> tb : POST /internal/trust/batch\n{"provider_ids": ["prov_A", "prov_B"]}
+activate tb
+tb -> db : Query trust scores
+db --> tb : Trust data
+tb --> be : {\n  "prov_A": {"score": 0.92, "tier": "TRUSTED"},\n  "prov_B": {"score": 0.78, "tier": "VERIFIED"}\n}
+deactivate tb
+
+== Calculate Scores ==
+
+note over be
+  **Balanced Strategy Weights:**
+  - Price: 0.30
+  - Trust: 0.30
+  - Confidence: 0.15
+  - MVP Sample: 0.15
+  - SLA: 0.10
+
+  **Bid A (Legal Agent A - Claude):**
+  - Price Score: 0.40 (higher price)
+  - Trust Score: 0.92
+  - Confidence: 0.95
+  - SLA Score: 1.0 (meets requirement)
+  - **Total: 0.30×0.40 + 0.30×0.92 + 0.15×0.95 + 0.15×0.80 + 0.10×1.0 = 0.76**
+
+  **Bid B (Legal Agent B - Gemini):**
+  - Price Score: 0.50 (lower price)
+  - Trust Score: 0.78
+  - Confidence: 0.85
+  - SLA Score: 1.0
+  - **Total: 0.30×0.50 + 0.30×0.78 + 0.15×0.85 + 0.15×0.70 + 0.10×1.0 = 0.72**
+
+  **Winner: Bid A (Legal Agent A)**
+end note
+
+be -> be : Filter invalid bids\n(price > budget, expired, SLA mismatch)
+be -> be : Calculate scores per strategy
+be -> be : Rank bids by total score
+
+be -> db : Store evaluation result
+be --> wp : EvaluationResult\n{\n  ranked_bids: [Bid_A, Bid_B],\n  winner: "bid_A",\n  scores: {...}\n}
+deactivate be
+
+wp -> wp : Set work state = "EVALUATED"
+wp -> wp : Publish event:\n"bids.evaluated"
+
+@enduml

--- a/documents/a2a-integration/diagrams/04-contract-award-a2a-handoff.puml
+++ b/documents/a2a-integration/diagrams/04-contract-award-a2a-handoff.puml
@@ -1,0 +1,117 @@
+@startuml Contract_Award_A2A_Handoff
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 4. Contract Award & A2A Handoff
+
+participant "Orchestrator Agent\n(Consumer)" as orch #LightGreen
+participant "AEX Gateway\n:8080" as gw #LightYellow
+participant "AEX Contract Engine\n:8084" as ce #LightYellow
+participant "AEX Provider Registry\n:8085" as pr #LightYellow
+participant "AEX Bid Gateway\n:8082" as bg #LightYellow
+participant "Token Service" as ts #LightGreen
+database "MongoDB" as db #LightBlue
+participant "Legal Agent A\n(A2A Server)" as la #LightPink
+
+== Award Contract ==
+
+orch -> gw : POST /v1/contracts/award\n{\n  "work_id": "work_xyz",\n  "bid_id": "bid_A"\n}
+activate gw
+
+gw -> ce : Forward award request
+activate ce
+
+ce -> bg : GET /internal/bids/{bid_id}
+activate bg
+bg --> ce : Bid details\n{provider_id, price, sla, ...}
+deactivate bg
+
+ce -> pr : GET /internal/providers/{provider_id}
+activate pr
+pr --> ce : Provider details\n{\n  preferred_interface: {\n    url: "https://legal-agent-a.example/a2a",\n    protocol_binding: "JSONRPC"\n  },\n  security_schemes: ["Bearer"]\n}
+deactivate pr
+
+== Generate Contract Token (JWT) ==
+
+ce -> ts : GenerateContractToken(claims)
+activate ts
+note right of ts
+  JWT Claims:
+  - iss: "aex"
+  - aud: "legal-agent-a.example"
+  - sub: "orchestrator_agent_id"
+  - work_id: "work_xyz"
+  - contract_id: "contract_123"
+  - provider_id: "prov_A"
+  - price_microunits: 30000000
+  - scope: ["a2a:message:send", "a2a:message:stream"]
+  - exp: (now + 1 hour)
+  - jti: "unique_token_id"
+end note
+
+ts -> ts : Sign with ES256 private key
+ts --> ce : Contract Token (JWT)
+deactivate ts
+
+== Store Contract ==
+
+ce -> ce : Generate contract_id
+ce -> ce : Set status = "AWARDED"
+
+ce -> db : Insert contract
+activate db
+note right of db
+  Contract document:
+  - contract_id
+  - work_id
+  - bid_id
+  - consumer_id
+  - provider_id
+  - agreed_price: 30.00
+  - provider_endpoint (A2A URL)
+  - execution_token (JWT hash)
+  - status: "AWARDED"
+  - expires_at
+  - awarded_at
+end note
+db --> ce : Inserted
+deactivate db
+
+ce -> ce : Publish event:\n"contract.awarded"
+
+== Return A2A Endpoint to Consumer ==
+
+ce --> gw : 200 OK\n{\n  "contract_id": "contract_123",\n  "work_id": "work_xyz",\n  "provider_id": "prov_A",\n  "agreed_price": 30.00,\n  "status": "AWARDED",\n  **"provider_a2a_endpoint": "https://legal-agent-a.example/a2a",**\n  **"protocol_binding": "JSONRPC",**\n  **"contract_token": "eyJhbGciOiJFUzI1NiIs...",**\n  "security_schemes": ["Bearer"],\n  "expires_at": "2026-01-02T13:00:00Z"\n}
+deactivate ce
+
+gw --> orch : Contract award response
+deactivate gw
+
+== Direct A2A Execution (AEX Exits Data Path) ==
+
+note over orch, la
+  **AEX is now out of the execution path**
+  Consumer communicates directly with Provider via A2A Protocol
+end note
+
+orch -> la : **POST https://legal-agent-a.example/a2a**\nContent-Type: application/json\n**Authorization: Bearer {contract_token}**\n\n{\n  "jsonrpc": "2.0",\n  "method": "message/send",\n  "id": "req_001",\n  "params": {\n    "message": {\n      "role": "user",\n      "parts": [{\n        "type": "text",\n        "text": "Please review this partnership contract..."\n      }]\n    }\n  }\n}
+activate la
+
+la -> la : Validate contract_token\n(fetch JWKS from AEX)
+la -> la : Verify signature & claims
+la -> la : Check scope allows "a2a:message:send"
+la -> la : Process with Claude LLM
+
+la --> orch : **A2A Response**\n{\n  "jsonrpc": "2.0",\n  "id": "req_001",\n  "result": {\n    "task": {\n      "id": "task_456",\n      "status": {"state": "COMPLETED"},\n      "artifacts": [{\n        "parts": [{\n          "type": "text",\n          "text": "Contract Analysis Report:\\n\\n1. Key Risks..."\n        }]\n      }]\n    }\n  }\n}
+deactivate la
+
+note over orch
+  Orchestrator receives results
+  directly from Provider Agent
+  via standard A2A Protocol
+end note
+
+@enduml

--- a/documents/a2a-integration/diagrams/05-settlement-trust-update.puml
+++ b/documents/a2a-integration/diagrams/05-settlement-trust-update.puml
@@ -1,0 +1,138 @@
+@startuml Settlement_Trust_Update
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 5. Settlement & Trust Update
+
+participant "Legal Agent A\n(Provider)" as la #LightPink
+participant "Orchestrator Agent\n(Consumer)" as orch #LightGreen
+participant "AEX Gateway\n:8080" as gw #LightYellow
+participant "AEX Contract Engine\n:8084" as ce #LightYellow
+participant "AEX Settlement\n:8088" as st #LightYellow
+participant "AEX Trust Broker\n:8086" as tb #LightYellow
+database "MongoDB" as db #LightBlue
+
+== Task Completion (A2A) ==
+
+note over la, orch
+  A2A task execution completed
+  Provider has delivered results
+end note
+
+== Report Completion to AEX ==
+
+la -> gw : POST /v1/contracts/{contract_id}/complete\n{\n  "success": true,\n  "result_summary": "Contract reviewed, 3 risks identified",\n  "metrics": {\n    "processing_time_ms": 12500,\n    "tokens_used": 4500\n  },\n  "a2a_task_id": "task_456"\n}
+activate gw
+
+gw -> ce : Forward completion
+activate ce
+
+ce -> db : Get contract
+activate db
+db --> ce : Contract details
+deactivate db
+
+ce -> ce : Validate:\n- Contract exists\n- Status is AWARDED/EXECUTING\n- Provider matches
+
+ce -> ce : Set status = "COMPLETED"
+ce -> ce : Record outcome
+
+ce -> db : Update contract
+activate db
+db --> ce : Updated
+deactivate db
+
+== Trigger Settlement ==
+
+ce -> st : POST /internal/settlement/complete\n{\n  "contract_id": "contract_123",\n  "work_id": "work_xyz",\n  "consumer_id": "orch_001",\n  "provider_id": "prov_A",\n  "agreed_price": "30.00",\n  "outcome": "SUCCESS"\n}
+activate st
+
+st -> st : Calculate cost breakdown
+note right of st
+  **Cost Calculation:**
+  Agreed Price: $30.00
+  Platform Fee (15%): $4.50
+  Provider Payout: $25.50
+end note
+
+st -> db : Create ledger entries
+activate db
+note right of db
+  **Ledger Entries:**
+  1. DEBIT consumer: $30.00
+  2. CREDIT provider: $25.50
+  3. CREDIT platform: $4.50
+end note
+db --> st : Entries created
+deactivate db
+
+st -> db : Update balances
+activate db
+note right of db
+  - consumer_balance -= $30.00
+  - provider_balance += $25.50
+  - platform_balance += $4.50
+end note
+db --> st : Balances updated
+deactivate db
+
+st -> db : Create execution record
+db --> st : Created
+
+st -> st : Publish event:\n"settlement.completed"
+
+st --> ce : Settlement result\n{\n  settlement_id,\n  platform_fee: "4.50",\n  provider_payout: "25.50"\n}
+deactivate st
+
+== Update Trust Score ==
+
+ce -> tb : POST /internal/outcomes\n{\n  "provider_id": "prov_A",\n  "contract_id": "contract_123",\n  "outcome": "SUCCESS",\n  "metrics": {\n    "response_time_ms": 12500,\n    "consumer_rating": null\n  }\n}
+activate tb
+
+tb -> db : Get provider trust record
+activate db
+db --> tb : Current trust data\n{score: 0.92, contracts: 47, outcomes: [...]}
+deactivate db
+
+tb -> tb : Add outcome to history
+tb -> tb : Recalculate weighted score
+note right of tb
+  **Trust Score Update:**
+  - Add SUCCESS (1.0) to outcomes
+  - Recent 10 contracts: weight 1.0
+  - Contracts 11-50: weight 0.5
+  - New score: 0.925
+  - Total contracts: 48
+  - Success rate: 94.8%
+  - Tier: TRUSTED (unchanged)
+end note
+
+tb -> db : Update trust record
+activate db
+db --> tb : Updated
+deactivate db
+
+tb --> ce : Trust updated\n{new_score: 0.925, tier: "TRUSTED"}
+deactivate tb
+
+ce -> ce : Publish event:\n"contract.completed"
+
+ce --> gw : 200 OK\n{\n  "contract_id": "contract_123",\n  "status": "COMPLETED",\n  "settlement": {\n    "settlement_id": "settle_789",\n    "agreed_price": "30.00",\n    "platform_fee": "4.50",\n    "provider_payout": "25.50"\n  },\n  "trust_update": {\n    "new_score": 0.925,\n    "tier": "TRUSTED"\n  }\n}
+deactivate ce
+
+gw --> la : Completion acknowledged
+deactivate gw
+
+== Consumer Notification (Optional) ==
+
+orch -> gw : GET /v1/contracts/{contract_id}
+activate gw
+gw -> ce : Get contract
+ce --> gw : Contract with settlement info
+gw --> orch : Contract details\n(status: COMPLETED, settlement info)
+deactivate gw
+
+@enduml

--- a/documents/a2a-integration/diagrams/06-complete-demo-flow.puml
+++ b/documents/a2a-integration/diagrams/06-complete-demo-flow.puml
@@ -1,0 +1,172 @@
+@startuml Complete_Demo_Flow
+
+
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 200
+
+title 6. Complete Demo Flow - Multi-Agent Legal & Travel Scenario
+
+actor "User" as user
+participant "Demo UI\n(Mesop)" as ui #LightBlue
+participant "Orchestrator\n(Claude)" as orch #LightGreen
+box "Agent Exchange" #LightYellow
+    participant "AEX\nGateway" as gw
+    participant "AEX\nServices" as aex
+end box
+participant "Legal Agent A\n(Claude)" as la #LightPink
+participant "Travel Agent\n(GPT-4)" as ta #LightCoral
+participant "Legal Agent B\n(Gemini)" as lb #Plum
+
+== User Request ==
+
+user -> ui : "Plan my Berlin trip next week.\nReview partnership contract.\nCheck German regulations."
+
+ui -> orch : Forward multi-task request
+activate orch
+
+orch -> orch : **Task Decomposition**\n(LangGraph + Claude)
+
+note right of orch
+  Identified 3 subtasks:
+  1. Contract Review (legal)
+  2. Travel Booking (travel)
+  3. Compliance Check (legal)
+end note
+
+== Parallel Work Submissions ==
+
+par Submit all work requests
+    orch -> gw : POST /v1/work\n{skill: "contract_review"}
+    gw -> aex : Process
+    aex --> gw : work_id: "work_001"
+    gw --> orch : Work 1 created
+and
+    orch -> gw : POST /v1/work\n{skill: "flight_booking"}
+    gw -> aex : Process
+    aex --> gw : work_id: "work_002"
+    gw --> orch : Work 2 created
+and
+    orch -> gw : POST /v1/work\n{skill: "compliance_check"}
+    gw -> aex : Process
+    aex --> gw : work_id: "work_003"
+    gw --> orch : Work 3 created
+end
+
+== Provider Discovery & Bidding ==
+
+note over aex
+  AEX discovers providers by skills:
+  - Work 1: Legal Agent A, Legal Agent B
+  - Work 2: Travel Agent
+  - Work 3: Legal Agent B
+end note
+
+par Providers receive opportunities and bid
+    aex -> la : Opportunity: work_001
+    la -> gw : POST /v1/bids {work_001, $30}
+and
+    aex -> lb : Opportunity: work_001
+    lb -> gw : POST /v1/bids {work_001, $25}
+and
+    aex -> ta : Opportunity: work_002
+    ta -> gw : POST /v1/bids {work_002, $20}
+and
+    aex -> lb : Opportunity: work_003
+    lb -> gw : POST /v1/bids {work_003, $20}
+end
+
+== Bid Evaluation (30s window) ==
+
+aex -> aex : Evaluate bids\n(Balanced strategy)
+
+note over aex
+  **Evaluation Results:**
+
+  Work 1 (Contract Review):
+  - Legal Agent A: Score 0.87 ✓ WIN
+  - Legal Agent B: Score 0.76
+
+  Work 2 (Travel Booking):
+  - Travel Agent: Score 0.85 ✓ WIN
+
+  Work 3 (Compliance):
+  - Legal Agent B: Score 0.80 ✓ WIN
+end note
+
+== Contract Awards ==
+
+par Award all contracts
+    orch -> gw : POST /v1/contracts/award {work_001, bid_A}
+    aex -> aex : Generate contract token
+    gw --> orch : Contract 1\n{a2a_endpoint: legal-agent-a/a2a,\ntoken: "eyJ..."}
+and
+    orch -> gw : POST /v1/contracts/award {work_002, bid_travel}
+    aex -> aex : Generate contract token
+    gw --> orch : Contract 2\n{a2a_endpoint: travel-agent/a2a,\ntoken: "eyJ..."}
+and
+    orch -> gw : POST /v1/contracts/award {work_003, bid_B}
+    aex -> aex : Generate contract token
+    gw --> orch : Contract 3\n{a2a_endpoint: legal-agent-b/a2a,\ntoken: "eyJ..."}
+end
+
+== Direct A2A Execution (Parallel) ==
+
+note over orch, lb #LightGreen
+  **AEX exits data path**
+  Direct A2A communication begins
+end note
+
+par Execute all tasks via A2A
+    orch -> la : **A2A: message/send**\nAuth: Bearer {token_1}\n"Review this contract..."
+    activate la
+    la -> la : Claude processes\ncontract review
+    la --> orch : Task result:\n"3 risk areas identified..."
+    deactivate la
+and
+    orch -> ta : **A2A: message/send**\nAuth: Bearer {token_2}\n"Book flight to Berlin..."
+    activate ta
+    ta -> ta : GPT-4 processes\ntravel booking
+    ta --> orch : Task result:\n"Flight LHR→BER booked..."
+    deactivate ta
+and
+    orch -> lb : **A2A: message/send**\nAuth: Bearer {token_3}\n"Research German regulations..."
+    activate lb
+    lb -> lb : Gemini processes\ncompliance research
+    lb --> orch : Task result:\n"GDPR compliance required..."
+    deactivate lb
+end
+
+== Settlement ==
+
+par Report completions
+    la -> gw : POST /contracts/1/complete {success: true}
+    aex -> aex : Settlement:\n$30 - $4.50 fee = $25.50
+and
+    ta -> gw : POST /contracts/2/complete {success: true}
+    aex -> aex : Settlement:\n$20 - $3.00 fee = $17.00
+and
+    lb -> gw : POST /contracts/3/complete {success: true}
+    aex -> aex : Settlement:\n$20 - $3.00 fee = $17.00
+end
+
+note over aex
+  **Total Settlement:**
+  Consumer paid: $70.00
+  Platform fee: $10.50 (15%)
+  Providers received: $59.50
+
+  Trust scores updated for all providers
+end note
+
+== Result Aggregation ==
+
+orch -> orch : **Aggregate Results**\n(LangGraph)
+
+orch --> ui : Unified response
+
+ui --> user : **Your Business Trip Plan:**\n\n📋 **Contract Review:**\n3 risk areas identified in partnership agreement\n\n✈️ **Travel Booked:**\nFlight: LHR→BER, Jan 8\nHotel: Berlin Marriott, 3 nights\n\n📜 **German Regulations:**\nGDPR compliance checklist provided
+
+deactivate orch
+
+@enduml

--- a/documents/a2a-integration/diagrams/07-architecture-overview.puml
+++ b/documents/a2a-integration/diagrams/07-architecture-overview.puml
@@ -1,0 +1,105 @@
+@startuml Architecture_Overview
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam componentStyle rectangle
+
+title Agent Exchange + A2A Integration - Architecture Overview
+
+package "User Layer" {
+    [Demo UI (Mesop)] as ui #LightBlue
+}
+
+package "Consumer Layer" {
+    [Orchestrator Agent\n(LangGraph + Claude)] as orch #LightGreen
+    note right of orch
+        Responsibilities:
+        • Task decomposition
+        • AEX client integration
+        • A2A client for execution
+        • Result aggregation
+    end note
+}
+
+package "Agent Exchange (Existing Implementation)" #LightYellow {
+    [AEX Gateway\n:8080] as gw
+
+    package "Core Services" {
+        [Work Publisher\n:8081] as wp
+        [Bid Gateway\n:8082] as bg
+        [Bid Evaluator\n:8083] as be
+        [Contract Engine\n:8084] as ce
+        [Provider Registry\n:8085] as pr
+        [Trust Broker\n:8086] as tb
+        [Identity\n:8087] as id
+        [Settlement\n:8088] as st
+        [Telemetry\n:8089] as tel
+    }
+
+    package "New A2A Components" #LightGreen {
+        [Agent Card\nResolver] as acr
+        [Token\nService] as ts
+    }
+
+    database "MongoDB" as db
+}
+
+package "Provider Layer (A2A Servers)" #LightPink {
+    [Legal Agent A\n(Claude)] as la
+    [Travel Agent\n(GPT-4)] as ta
+    [Legal Agent B\n(Gemini)] as lb
+
+    note bottom of la
+        All providers:
+        • Expose /.well-known/agent-card.json
+        • Implement A2A JSON-RPC server
+        • Accept AEX contract tokens
+        • Use LangGraph framework
+    end note
+}
+
+cloud "LLM APIs" as llm {
+    [Anthropic API] as claude
+    [OpenAI API] as openai
+    [Google AI API] as gemini
+}
+
+' User flow
+ui --> orch : User request
+
+' AEX flow
+orch --> gw : REST API calls
+gw --> wp : Work submission
+gw --> bg : Bid queries
+gw --> ce : Contract award
+gw --> st : Settlement
+
+wp --> pr : Get subscribed providers
+pr --> acr : Fetch Agent Cards
+acr --> la : GET /.well-known/agent-card.json
+acr --> ta : GET /.well-known/agent-card.json
+acr --> lb : GET /.well-known/agent-card.json
+
+be --> tb : Get trust scores
+ce --> ts : Generate contract token
+
+wp --> db
+bg --> db
+be --> db
+ce --> db
+pr --> db
+tb --> db
+st --> db
+
+' A2A execution (direct)
+orch --> la : **A2A: message/send**\n(with contract token)
+orch --> ta : **A2A: message/send**\n(with contract token)
+orch --> lb : **A2A: message/send**\n(with contract token)
+
+' LLM connections
+la --> claude
+ta --> openai
+lb --> gemini
+orch --> claude
+
+@enduml

--- a/documents/a2a-integration/diagrams/08-gcp-deployment.puml
+++ b/documents/a2a-integration/diagrams/08-gcp-deployment.puml
@@ -1,0 +1,143 @@
+@startuml GCP_Deployment
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+
+title GCP Deployment Architecture
+
+cloud "Internet" as inet {
+}
+
+package "Google Cloud Platform" {
+
+    node "Cloud Load Balancer" as clb #LightBlue {
+        [Global HTTP(S)\nLoad Balancer] as glb
+    }
+
+    package "Cloud Run Services" #LightYellow {
+
+        package "AEX Services" {
+            [aex-gateway] as gw
+            [aex-work-publisher] as wp
+            [aex-bid-gateway] as bg
+            [aex-bid-evaluator] as be
+            [aex-contract-engine] as ce
+            [aex-provider-registry] as pr
+            [aex-trust-broker] as tb
+            [aex-identity] as id
+            [aex-settlement] as st
+            [aex-telemetry] as tel
+        }
+
+        package "Demo Services" #LightGreen {
+            [demo-ui\n(Mesop)] as ui
+            [orchestrator\n(Claude)] as orch
+        }
+
+        package "Provider Agents" #LightPink {
+            [legal-agent-a\n(Claude)] as la
+            [legal-agent-b\n(Gemini)] as lagentb
+            [travel-agent\n(GPT-4)] as ta
+        }
+    }
+
+    package "Data Services" #LightCoral {
+        database "Firestore" as fs {
+            [work_specs]
+            [providers]
+            [bids]
+            [contracts]
+            [ledger_entries]
+            [trust_scores]
+        }
+
+        storage "Cloud Storage" as cs {
+            [Documents]
+            [Artifacts]
+        }
+
+        [Secret Manager] as sm
+    }
+
+    package "Observability" #Wheat {
+        [Cloud Logging] as log
+        [Cloud Monitoring] as mon
+        [Cloud Trace] as trace
+    }
+
+    package "Container Registry" {
+        [Artifact Registry] as ar
+    }
+}
+
+cloud "External APIs" as ext {
+    [Anthropic API\n(Claude)] as claude
+    [OpenAI API\n(GPT-4)] as openai
+    [Google AI\n(Gemini)] as gemini
+}
+
+' Connections
+inet --> glb
+
+glb --> gw : /v1/*
+glb --> ui : /demo/*
+glb --> la : /a2a (legal-a)
+glb --> lagentb : /a2a (legal-b)
+glb --> ta : /a2a (travel)
+
+gw --> wp
+gw --> bg
+gw --> be
+gw --> ce
+gw --> pr
+gw --> tb
+gw --> st
+gw --> id
+
+wp --> fs
+bg --> fs
+ce --> fs
+pr --> fs
+tb --> fs
+st --> fs
+
+orch --> gw : AEX API
+orch --> la : A2A
+orch --> lagentb : A2A
+orch --> ta : A2A
+
+la --> claude
+lagentb --> gemini
+ta --> openai
+orch --> claude
+
+la --> sm : API keys
+lagentb --> sm : API keys
+ta --> sm : API keys
+
+gw --> log
+wp --> log
+ce --> log
+
+note right of fs
+  **Firestore Collections:**
+  - work_specs (Work Publisher)
+  - providers (Provider Registry)
+  - bids (Bid Gateway)
+  - evaluations (Bid Evaluator)
+  - contracts (Contract Engine)
+  - ledger_entries (Settlement)
+  - trust_scores (Trust Broker)
+  - tenants (Identity)
+end note
+
+note bottom of sm
+  **Secrets:**
+  - ANTHROPIC_API_KEY
+  - OPENAI_API_KEY
+  - GOOGLE_AI_API_KEY
+  - JWT_SIGNING_KEY
+  - MONGO_URI (if using MongoDB)
+end note
+
+@enduml

--- a/documents/a2a-integration/diagrams/09-demo-implementation-flow.puml
+++ b/documents/a2a-integration/diagrams/09-demo-implementation-flow.puml
@@ -1,0 +1,144 @@
+@startuml Demo_Implementation_Flow
+
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+skinparam maxMessageSize 250
+
+title 9. Demo Implementation - AEX Discovery + A2A Execution Flow
+
+actor "User" as user
+participant "Orchestrator\n:8103" as orch #LightGreen
+participant "Claude API\n(Anthropic)" as claude #LightBlue
+box "Agent Exchange" #LightYellow
+    participant "AEX Gateway\n:8080" as gw
+    participant "Provider Registry\n:8085" as reg
+end box
+participant "Legal Agent A\n:8100\n(Budget)" as la #LightPink
+participant "Legal Agent B\n:8101\n(Standard)" as lb #Plum
+participant "Legal Agent C\n:8102\n(Premium)" as lc #LightCoral
+
+== Phase 1: Agent Startup & Registration ==
+
+note over la, lc
+  On startup, each agent registers with AEX
+  using Docker network hostnames
+end note
+
+par Agent Registration
+    la -> gw : POST /v1/providers\n{name: "Legal Agent A",\nendpoint: "http://legal-agent-a:8100",\ncapabilities: ["contract_review",\n"risk_assessment"]}
+    gw -> reg : Store provider
+    reg --> gw : prov_83b1d3f3
+    gw --> la : 201 Created
+and
+    lb -> gw : POST /v1/providers\n{name: "Legal Agent B",\nendpoint: "http://legal-agent-b:8101",\ncapabilities: ["compliance_check",\n"regulatory_analysis"]}
+    gw -> reg : Store provider
+    reg --> gw : prov_a1c2d3e4
+    gw --> lb : 201 Created
+and
+    lc -> gw : POST /v1/providers\n{name: "Legal Agent C",\nendpoint: "http://legal-agent-c:8102",\ncapabilities: ["negotiation_support",\n"contract_drafting"]}
+    gw -> reg : Store provider
+    reg --> gw : prov_b2c3d4e5
+    gw --> lc : 201 Created
+end
+
+== Phase 2: User Request ==
+
+user -> orch : POST /a2a\n**A2A message/send**\n"Review this contract and\ncheck compliance"
+
+activate orch
+
+== Phase 3: Task Decomposition ==
+
+orch -> claude : POST /messages\n{model: "claude-sonnet-4-20250514",\nmessages: [user_request],\ntools: [decompose_task]}
+
+claude --> orch : Tool Call Response:\n**subtasks:**\n1. contract_review [contract_review]\n2. compliance_check [compliance_check]
+
+note right of orch
+  Claude identifies 2 subtasks
+  with skill_tags for each
+end note
+
+== Phase 4: AEX Provider Discovery ==
+
+note over orch, reg #LightGreen
+  **KEY STEP: AEX Discovery**
+  Orchestrator queries AEX to find
+  providers matching skill tags
+end note
+
+orch -> gw : GET /v1/providers/search\n?skills=contract_review
+
+gw -> reg : SearchBySkillTags\n(["contract_review"])
+
+reg -> reg : Query MongoDB:\ncapabilities contains\n"contract_review"
+
+reg --> gw : [{provider_id: "prov_83b1d3f3",\nname: "Legal Agent A",\nendpoint: "http://legal-agent-a:8100",\ntrust_score: 0.85}]
+
+gw --> orch : 200 OK\n{providers: [...]}
+
+note right of orch
+  Found: Legal Agent A
+  Selected based on trust score
+end note
+
+orch -> gw : GET /v1/providers/search\n?skills=compliance_check
+
+gw -> reg : SearchBySkillTags\n(["compliance_check"])
+
+reg --> gw : [{provider_id: "prov_a1c2d3e4",\nname: "Legal Agent B",\nendpoint: "http://legal-agent-b:8101",\ntrust_score: 0.80}]
+
+gw --> orch : 200 OK\n{providers: [...]}
+
+note right of orch
+  Found: Legal Agent B
+  Selected for compliance
+end note
+
+== Phase 5: Direct A2A Execution ==
+
+note over orch, lc #LightGreen
+  **AEX exits data path**
+  Direct A2A communication begins
+end note
+
+par Execute subtasks via A2A
+    orch -> la : POST /a2a\n**A2A message/send**\n"Review this contract..."
+    activate la
+    la -> claude : Process with Claude
+    claude --> la : Analysis result
+    la --> orch : {status: "completed",\nresult: "Contract analysis:\n3 risk areas identified..."}
+    deactivate la
+and
+    orch -> lb : POST /a2a\n**A2A message/send**\n"Check compliance..."
+    activate lb
+    lb -> claude : Process with Claude
+    claude --> lb : Compliance result
+    lb --> orch : {status: "completed",\nresult: "Compliance check:\nGDPR requirements..."}
+    deactivate lb
+end
+
+== Phase 6: Result Aggregation ==
+
+orch -> claude : POST /messages\n{Aggregate subtask results}
+
+claude --> orch : Combined summary with\nAgent Selection Table
+
+orch --> user : **A2A Response**\n\n## Summary\nContract reviewed, compliance checked\n\n## Agent Selection Summary\n| Task | Agent | Reason |\n|------|-------|--------|\n| contract_review | Legal Agent A | Budget tier |\n| compliance | Legal Agent B | Standard tier |
+
+deactivate orch
+
+== Data Flow Summary ==
+
+note over user, lc
+  **Protocol Usage:**
+  - Registration: REST API (AEX)
+  - Discovery: REST API (AEX)
+  - Execution: A2A Protocol (JSON-RPC 2.0)
+
+  **Key URLs:**
+  - AEX Gateway: http://aex-gateway:8080
+  - Provider Search: /v1/providers/search?skills=X
+  - A2A Endpoint: /a2a
+end note
+
+@enduml

--- a/documents/a2a-integration/diagrams/README.md
+++ b/documents/a2a-integration/diagrams/README.md
@@ -1,0 +1,96 @@
+# AEX + A2A Integration - PlantUML Diagrams
+
+This directory contains PlantUML sequence and architecture diagrams for the Agent Exchange + A2A Protocol integration.
+
+## Diagram Index
+
+| # | Diagram | Description |
+|---|---------|-------------|
+| 01 | [Provider Onboarding](01-provider-onboarding.puml) | Agent Card fetching and provider registration |
+| 02 | [Work Submission & Discovery](02-work-submission-discovery.puml) | Work creation and skill-based agent discovery |
+| 03 | [Bidding & Evaluation](03-bidding-evaluation.puml) | Bid submission, scoring, and ranking |
+| 04 | [Contract Award & A2A Handoff](04-contract-award-a2a-handoff.puml) | Contract creation and direct A2A execution |
+| 05 | [Settlement & Trust Update](05-settlement-trust-update.puml) | Payment processing and trust score updates |
+| 06 | [Complete Demo Flow](06-complete-demo-flow.puml) | End-to-end multi-agent scenario |
+| 07 | [Architecture Overview](07-architecture-overview.puml) | Component diagram showing all services |
+| 08 | [GCP Deployment](08-gcp-deployment.puml) | Cloud deployment architecture |
+| 09 | [Demo Implementation Flow](09-demo-implementation-flow.puml) | Actual demo call flow with AEX discovery |
+
+## How to View
+
+### Option 1: PlantUML Online Server
+Copy the content of any `.puml` file and paste it at:
+- https://www.plantuml.com/plantuml/uml/
+
+### Option 2: VS Code Extension
+Install the "PlantUML" extension and preview directly in VS Code.
+
+### Option 3: Command Line
+```bash
+# Install PlantUML
+brew install plantuml
+
+# Generate PNG for all diagrams
+for f in *.puml; do plantuml -tpng "$f"; done
+
+# Generate SVG for all diagrams
+for f in *.puml; do plantuml -tsvg "$f"; done
+```
+
+### Option 4: Docker
+```bash
+docker run -v $(pwd):/data plantuml/plantuml -tpng /data/*.puml
+```
+
+## Key Flows
+
+### 1. Provider Onboarding
+```
+Provider Agent → AEX Registry → Fetch Agent Card → Index Skills → Store
+```
+
+### 2. Work Execution Flow
+```
+User Request → Orchestrator → AEX (Discovery + Bidding + Award) → A2A Execution → Settlement
+```
+
+### 3. A2A Handoff Point
+The critical handoff occurs at **Contract Award**:
+- Before: All communication through AEX REST APIs
+- After: Direct A2A JSON-RPC between Consumer and Provider
+- AEX only re-enters for Settlement
+
+## Color Legend
+
+| Color | Meaning |
+|-------|---------|
+| 🟦 Light Blue | User Interface |
+| 🟩 Light Green | Consumer/Orchestrator + New Components |
+| 🟨 Light Yellow | Agent Exchange (Existing) |
+| 🟪 Light Pink | Provider Agents (A2A) |
+| 🟫 Light Blue (DB) | Data Storage |
+
+## Existing vs New Components
+
+### Existing (No Changes Needed)
+- AEX Gateway
+- AEX Work Publisher
+- AEX Bid Gateway
+- AEX Bid Evaluator
+- AEX Contract Engine
+- AEX Settlement
+- AEX Trust Broker
+- AEX Identity
+- AEX Telemetry
+
+### New Components to Add
+- **Agent Card Resolver** - Fetch and validate A2A Agent Cards
+- **Token Service** - Generate JWT contract tokens
+- **Skills Index** - Query providers by A2A skills/tags
+
+### New (Demo Only)
+- Orchestrator Agent (LangGraph + Claude)
+- Legal Agent A (LangGraph + Claude)
+- Legal Agent B (LangGraph + Gemini)
+- Travel Agent (LangGraph + GPT-4)
+- Demo UI (Mesop)

--- a/documents/a2a-integration/diagrams/call-flows.puml
+++ b/documents/a2a-integration/diagrams/call-flows.puml
@@ -1,0 +1,35 @@
+@startuml AEX_A2A_Integration_Overview
+
+!theme plain
+skinparam backgroundColor #FEFEFE
+skinparam sequenceMessageAlign center
+
+title Agent Exchange + A2A Integration - System Overview
+
+actor "User" as user
+participant "Demo UI\n(Mesop)" as ui #LightBlue
+participant "Orchestrator Agent\n(Consumer)" as orch #LightGreen
+box "Agent Exchange (Existing)" #LightYellow
+    participant "AEX Gateway" as gw
+    participant "AEX Work Publisher" as wp
+    participant "AEX Provider Registry" as pr
+    participant "AEX Bid Gateway" as bg
+    participant "AEX Bid Evaluator" as be
+    participant "AEX Contract Engine" as ce
+    participant "AEX Settlement" as st
+    participant "AEX Trust Broker" as tb
+end box
+box "Provider Agents (A2A)" #LightPink
+    participant "Legal Agent A\n(Claude)" as la
+    participant "Travel Agent\n(GPT-4)" as ta
+    participant "Legal Agent B\n(Gemini)" as lb
+end box
+
+user -> ui : "Plan my Berlin trip,\nreview contract,\ncheck regulations"
+ui -> orch : Forward request
+
+note over orch : Task Decomposition\n(LangGraph + Claude)
+
+orch -> orch : Identify subtasks:\n1. Contract Review\n2. Travel Booking\n3. Compliance Check
+
+@enduml

--- a/src/aex-provider-registry/internal/config/config.go
+++ b/src/aex-provider-registry/internal/config/config.go
@@ -17,9 +17,15 @@ type Config struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	IdleTimeout  time.Duration
+
+	// AllowHTTP allows HTTP URLs in development mode
+	AllowHTTP bool
 }
 
 func Load() Config {
+	env := strings.ToLower(getenv("ENVIRONMENT", "production"))
+	allowHTTP := env == "development" || env == "dev" || env == "local"
+
 	return Config{
 		Port:                     getenv("PORT", "8080"),
 		MongoURI:                 strings.TrimSpace(os.Getenv("MONGO_URI")),
@@ -29,6 +35,7 @@ func Load() Config {
 		ReadTimeout:              10 * time.Second,
 		WriteTimeout:             20 * time.Second,
 		IdleTimeout:              60 * time.Second,
+		AllowHTTP:                allowHTTP,
 	}
 }
 

--- a/src/aex-provider-registry/internal/httpapi/router.go
+++ b/src/aex-provider-registry/internal/httpapi/router.go
@@ -8,13 +8,31 @@ import (
 
 func NewRouter(svc *service.Service) http.Handler {
 	mux := http.NewServeMux()
+
+	// Provider management
 	mux.HandleFunc("POST /v1/providers", svc.HandleRegisterProvider)
+	mux.HandleFunc("GET /v1/providers", svc.HandleListAllProviders)
+	mux.HandleFunc("GET /v1/providers/search", svc.HandleSearchProviders)
+
+	// Provider details (must come after /search to avoid conflicts)
+	mux.HandleFunc("GET /v1/providers/{provider_id}/a2a", svc.HandleGetProviderWithA2A)
+	mux.HandleFunc("POST /v1/providers/{provider_id}/agent-card", svc.HandleRegisterAgentCard)
+	mux.HandleFunc("GET /v1/providers/{provider_id}", svc.HandleGetProvider)
+
+	// Legacy single provider endpoint (fallback)
 	mux.HandleFunc("GET /v1/providers/", svc.HandleGetProvider)
+
+	// Subscriptions
 	mux.HandleFunc("POST /v1/subscriptions", svc.HandleCreateSubscription)
 	mux.HandleFunc("GET /v1/subscriptions", svc.HandleListSubscriptions)
+
+	// Internal APIs
 	mux.HandleFunc("GET /internal/v1/providers/subscribed", svc.HandleInternalSubscribed)
 	mux.HandleFunc("GET /internal/v1/providers/validate-key", svc.HandleValidateAPIKey)
+
+	// Health check
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+
 	return mux
 }
 

--- a/src/aex-provider-registry/internal/model/model.go
+++ b/src/aex-provider-registry/internal/model/model.go
@@ -97,5 +97,83 @@ type SubscriptionResponse struct {
 	CreatedAt      time.Time `json:"created_at"`
 }
 
+// A2A Agent Card models
 
+type AgentCard struct {
+	Name             string            `json:"name" bson:"name"`
+	Description      string            `json:"description" bson:"description"`
+	URL              string            `json:"url" bson:"url"`
+	Version          string            `json:"version" bson:"version"`
+	Provider         *AgentProvider    `json:"provider,omitempty" bson:"provider,omitempty"`
+	DocumentationURL string            `json:"documentationUrl,omitempty" bson:"documentation_url,omitempty"`
+	Capabilities     AgentCapabilities `json:"capabilities" bson:"capabilities"`
+	Skills           []AgentSkill      `json:"skills" bson:"skills"`
+}
+
+type AgentProvider struct {
+	Organization string `json:"organization" bson:"organization"`
+	URL          string `json:"url,omitempty" bson:"url,omitempty"`
+}
+
+type AgentCapabilities struct {
+	Streaming              bool `json:"streaming,omitempty" bson:"streaming,omitempty"`
+	PushNotifications      bool `json:"pushNotifications,omitempty" bson:"push_notifications,omitempty"`
+	StateTransitionHistory bool `json:"stateTransitionHistory,omitempty" bson:"state_transition_history,omitempty"`
+}
+
+type AgentSkill struct {
+	ID          string   `json:"id" bson:"id"`
+	Name        string   `json:"name" bson:"name"`
+	Description string   `json:"description,omitempty" bson:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty" bson:"tags,omitempty"`
+	Examples    []string `json:"examples,omitempty" bson:"examples,omitempty"`
+	InputModes  []string `json:"inputModes,omitempty" bson:"input_modes,omitempty"`
+	OutputModes []string `json:"outputModes,omitempty" bson:"output_modes,omitempty"`
+}
+
+// SkillIndex for fast skill-based lookups
+type SkillIndex struct {
+	SkillID     string    `json:"skill_id" bson:"skill_id"`
+	SkillName   string    `json:"skill_name" bson:"skill_name"`
+	Description string    `json:"description" bson:"description"`
+	Tags        []string  `json:"tags" bson:"tags"`
+	ProviderID  string    `json:"provider_id" bson:"provider_id"`
+	AgentName   string    `json:"agent_name" bson:"agent_name"`
+	AgentURL    string    `json:"agent_url" bson:"agent_url"`
+	A2AEndpoint string    `json:"a2a_endpoint" bson:"a2a_endpoint"`
+	CreatedAt   time.Time `json:"created_at" bson:"created_at"`
+}
+
+// ProviderWithA2A extends Provider with A2A information
+type ProviderWithA2A struct {
+	Provider
+	AgentCard   *AgentCard `json:"agent_card,omitempty" bson:"agent_card,omitempty"`
+	A2AEndpoint string     `json:"a2a_endpoint,omitempty" bson:"a2a_endpoint,omitempty"`
+}
+
+// SearchProvidersRequest for skill-based search
+type SearchProvidersRequest struct {
+	SkillTags []string `json:"skill_tags,omitempty"`
+	Domain    string   `json:"domain,omitempty"`
+	MinTrust  float64  `json:"min_trust,omitempty"`
+	Limit     int      `json:"limit,omitempty"`
+}
+
+// SearchProvidersResponse contains matching providers
+type SearchProvidersResponse struct {
+	Providers []ProviderSearchResult `json:"providers"`
+	Total     int                    `json:"total"`
+}
+
+type ProviderSearchResult struct {
+	ProviderID  string   `json:"provider_id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Endpoint    string   `json:"endpoint"`
+	A2AEndpoint string   `json:"a2a_endpoint"`
+	TrustScore  float64  `json:"trust_score"`
+	TrustTier   string   `json:"trust_tier"`
+	Skills      []string `json:"skills"`
+	MatchedTags []string `json:"matched_tags"`
+}
 

--- a/src/aex-provider-registry/internal/store/memory.go
+++ b/src/aex-provider-registry/internal/store/memory.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/parlakisik/agent-exchange/aex-provider-registry/internal/model"
 )
@@ -11,12 +12,18 @@ type MemoryStore struct {
 	mu            sync.RWMutex
 	providers     map[string]model.Provider
 	subscriptions map[string]model.Subscription
+	agentCards    map[string]model.AgentCard
+	a2aEndpoints  map[string]string
+	skillIndex    map[string][]model.SkillIndex // tag -> skills
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
 		providers:     map[string]model.Provider{},
 		subscriptions: map[string]model.Subscription{},
+		agentCards:    map[string]model.AgentCard{},
+		a2aEndpoints:  map[string]string{},
+		skillIndex:    map[string][]model.SkillIndex{},
 	}
 }
 
@@ -85,4 +92,152 @@ func (s *MemoryStore) ListSubscriptions(ctx context.Context) ([]model.Subscripti
 	return out, nil
 }
 
+func (s *MemoryStore) ListAllProviders(ctx context.Context) ([]model.Provider, error) {
+	_ = ctx
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]model.Provider, 0, len(s.providers))
+	for _, p := range s.providers {
+		out = append(out, p)
+	}
+	return out, nil
+}
 
+func (s *MemoryStore) UpdateProvider(ctx context.Context, p model.Provider) error {
+	_ = ctx
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.providers[p.ProviderID]; !ok {
+		return nil
+	}
+	s.providers[p.ProviderID] = p
+	return nil
+}
+
+func (s *MemoryStore) SaveAgentCard(ctx context.Context, providerID string, card model.AgentCard, a2aEndpoint string) error {
+	_ = ctx
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agentCards[providerID] = card
+	s.a2aEndpoints[providerID] = a2aEndpoint
+	return nil
+}
+
+func (s *MemoryStore) GetProviderWithA2A(ctx context.Context, providerID string) (*model.ProviderWithA2A, error) {
+	_ = ctx
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.providers[providerID]
+	if !ok {
+		return nil, nil
+	}
+	result := &model.ProviderWithA2A{
+		Provider:    p,
+		A2AEndpoint: s.a2aEndpoints[providerID],
+	}
+	if card, ok := s.agentCards[providerID]; ok {
+		result.AgentCard = &card
+	}
+	return result, nil
+}
+
+func (s *MemoryStore) IndexSkills(ctx context.Context, providerID string, skills []model.SkillIndex) error {
+	_ = ctx
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove old skills for this provider
+	for tag, indexedSkills := range s.skillIndex {
+		filtered := make([]model.SkillIndex, 0)
+		for _, skill := range indexedSkills {
+			if skill.ProviderID != providerID {
+				filtered = append(filtered, skill)
+			}
+		}
+		s.skillIndex[tag] = filtered
+	}
+
+	// Add new skills
+	now := time.Now()
+	for _, skill := range skills {
+		skill.CreatedAt = now
+		// Index by each tag
+		for _, tag := range skill.Tags {
+			s.skillIndex[tag] = append(s.skillIndex[tag], skill)
+		}
+		// Also index by skill ID
+		s.skillIndex[skill.SkillID] = append(s.skillIndex[skill.SkillID], skill)
+	}
+	return nil
+}
+
+func (s *MemoryStore) SearchBySkillTags(ctx context.Context, tags []string, minTrust float64, limit int) ([]model.ProviderSearchResult, error) {
+	_ = ctx
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	// Find providers matching tags
+	providerMatches := make(map[string]map[string]bool) // providerID -> matched tags
+	providerSkills := make(map[string][]string)         // providerID -> skill IDs
+
+	for _, tag := range tags {
+		if skills, ok := s.skillIndex[tag]; ok {
+			for _, skill := range skills {
+				if providerMatches[skill.ProviderID] == nil {
+					providerMatches[skill.ProviderID] = make(map[string]bool)
+				}
+				providerMatches[skill.ProviderID][tag] = true
+				// Track skills
+				found := false
+				for _, sid := range providerSkills[skill.ProviderID] {
+					if sid == skill.SkillID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					providerSkills[skill.ProviderID] = append(providerSkills[skill.ProviderID], skill.SkillID)
+				}
+			}
+		}
+	}
+
+	// Build results
+	results := make([]model.ProviderSearchResult, 0)
+	for providerID, matchedTags := range providerMatches {
+		p, ok := s.providers[providerID]
+		if !ok || p.Status != model.ProviderStatusActive {
+			continue
+		}
+		if p.TrustScore < minTrust {
+			continue
+		}
+
+		tags := make([]string, 0, len(matchedTags))
+		for tag := range matchedTags {
+			tags = append(tags, tag)
+		}
+
+		results = append(results, model.ProviderSearchResult{
+			ProviderID:  p.ProviderID,
+			Name:        p.Name,
+			Description: p.Description,
+			Endpoint:    p.Endpoint,
+			A2AEndpoint: s.a2aEndpoints[providerID],
+			TrustScore:  p.TrustScore,
+			TrustTier:   string(p.TrustTier),
+			Skills:      providerSkills[providerID],
+			MatchedTags: tags,
+		})
+
+		if len(results) >= limit {
+			break
+		}
+	}
+
+	return results, nil
+}

--- a/src/aex-provider-registry/internal/store/mongo.go
+++ b/src/aex-provider-registry/internal/store/mongo.go
@@ -11,15 +11,19 @@ import (
 )
 
 type MongoStore struct {
-	providers *mongo.Collection
-	subs      *mongo.Collection
+	providers   *mongo.Collection
+	subs        *mongo.Collection
+	agentCards  *mongo.Collection
+	skillIndex  *mongo.Collection
 }
 
 func NewMongoStore(client *mongo.Client, dbName, providersColl, subsColl string) *MongoStore {
 	db := client.Database(dbName)
 	return &MongoStore{
-		providers: db.Collection(providersColl),
-		subs:      db.Collection(subsColl),
+		providers:   db.Collection(providersColl),
+		subs:        db.Collection(subsColl),
+		agentCards:  db.Collection("agent_cards"),
+		skillIndex:  db.Collection("skill_index"),
 	}
 }
 
@@ -41,6 +45,26 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 	_, err = s.subs.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.D{{Key: "subscription_id", Value: 1}},
 		Options: options.Index().SetUnique(true),
+	})
+	if err != nil {
+		return err
+	}
+	// A2A indexes
+	_, err = s.agentCards.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys:    bson.D{{Key: "provider_id", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = s.skillIndex.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "tags", Value: 1}},
+	})
+	if err != nil {
+		return err
+	}
+	_, err = s.skillIndex.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "provider_id", Value: 1}},
 	})
 	return err
 }
@@ -137,4 +161,250 @@ func (s *MongoStore) ListSubscriptions(ctx context.Context) ([]model.Subscriptio
 	return out, nil
 }
 
+func (s *MongoStore) ListAllProviders(ctx context.Context) ([]model.Provider, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cur, err := s.providers.Find(ctx, bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	defer cur.Close(ctx)
+	var out []model.Provider
+	for cur.Next(ctx) {
+		var p model.Provider
+		if err := cur.Decode(&p); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, cur.Err()
+}
 
+func (s *MongoStore) UpdateProvider(ctx context.Context, p model.Provider) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, err := s.providers.UpdateOne(ctx,
+		bson.M{"provider_id": p.ProviderID},
+		bson.M{"$set": p},
+	)
+	return err
+}
+
+// agentCardDoc wraps AgentCard with provider info for storage
+type agentCardDoc struct {
+	ProviderID  string          `bson:"provider_id"`
+	A2AEndpoint string          `bson:"a2a_endpoint"`
+	AgentCard   model.AgentCard `bson:"agent_card"`
+	UpdatedAt   time.Time       `bson:"updated_at"`
+}
+
+func (s *MongoStore) SaveAgentCard(ctx context.Context, providerID string, card model.AgentCard, a2aEndpoint string) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	doc := agentCardDoc{
+		ProviderID:  providerID,
+		A2AEndpoint: a2aEndpoint,
+		AgentCard:   card,
+		UpdatedAt:   time.Now(),
+	}
+
+	_, err := s.agentCards.UpdateOne(ctx,
+		bson.M{"provider_id": providerID},
+		bson.M{"$set": doc},
+		options.Update().SetUpsert(true),
+	)
+	return err
+}
+
+func (s *MongoStore) GetProviderWithA2A(ctx context.Context, providerID string) (*model.ProviderWithA2A, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Get provider
+	res := s.providers.FindOne(ctx, bson.M{"provider_id": providerID})
+	if res.Err() == mongo.ErrNoDocuments {
+		return nil, nil
+	}
+	if res.Err() != nil {
+		return nil, res.Err()
+	}
+	var p model.Provider
+	if err := res.Decode(&p); err != nil {
+		return nil, err
+	}
+
+	result := &model.ProviderWithA2A{Provider: p}
+
+	// Get agent card
+	cardRes := s.agentCards.FindOne(ctx, bson.M{"provider_id": providerID})
+	if cardRes.Err() == nil {
+		var doc agentCardDoc
+		if err := cardRes.Decode(&doc); err == nil {
+			result.AgentCard = &doc.AgentCard
+			result.A2AEndpoint = doc.A2AEndpoint
+		}
+	}
+
+	return result, nil
+}
+
+func (s *MongoStore) IndexSkills(ctx context.Context, providerID string, skills []model.SkillIndex) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Delete existing skills for this provider
+	_, err := s.skillIndex.DeleteMany(ctx, bson.M{"provider_id": providerID})
+	if err != nil {
+		return err
+	}
+
+	if len(skills) == 0 {
+		return nil
+	}
+
+	// Insert new skills
+	now := time.Now()
+	docs := make([]interface{}, len(skills))
+	for i, skill := range skills {
+		skill.CreatedAt = now
+		docs[i] = skill
+	}
+
+	_, err = s.skillIndex.InsertMany(ctx, docs)
+	return err
+}
+
+func (s *MongoStore) SearchBySkillTags(ctx context.Context, tags []string, minTrust float64, limit int) ([]model.ProviderSearchResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	// Group by provider
+	providerSkills := make(map[string][]model.SkillIndex)
+	providerTags := make(map[string]map[string]bool)
+
+	// First, try skill_index collection
+	cur, err := s.skillIndex.Find(ctx, bson.M{"tags": bson.M{"$in": tags}})
+	if err == nil {
+		defer cur.Close(ctx)
+		for cur.Next(ctx) {
+			var skill model.SkillIndex
+			if err := cur.Decode(&skill); err != nil {
+				continue
+			}
+			providerSkills[skill.ProviderID] = append(providerSkills[skill.ProviderID], skill)
+			if providerTags[skill.ProviderID] == nil {
+				providerTags[skill.ProviderID] = make(map[string]bool)
+			}
+			for _, tag := range skill.Tags {
+				for _, searchTag := range tags {
+					if tag == searchTag {
+						providerTags[skill.ProviderID][tag] = true
+					}
+				}
+			}
+		}
+	}
+
+	// Also search providers by capabilities (fallback for simple registration)
+	provCur, err := s.providers.Find(ctx, bson.M{
+		"capabilities": bson.M{"$in": tags},
+		"status":       model.ProviderStatusActive,
+	})
+	if err == nil {
+		defer provCur.Close(ctx)
+		for provCur.Next(ctx) {
+			var p model.Provider
+			if err := provCur.Decode(&p); err != nil {
+				continue
+			}
+			// Add to results if not already from skill_index
+			if _, exists := providerSkills[p.ProviderID]; !exists {
+				providerSkills[p.ProviderID] = nil // mark as from capabilities
+				providerTags[p.ProviderID] = make(map[string]bool)
+				for _, cap := range p.Capabilities {
+					for _, searchTag := range tags {
+						if cap == searchTag {
+							providerTags[p.ProviderID][cap] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Get provider details
+	providerIDs := make([]string, 0, len(providerSkills))
+	for pid := range providerSkills {
+		providerIDs = append(providerIDs, pid)
+	}
+
+	providers, err := s.ListProviders(ctx, providerIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	providerMap := make(map[string]model.Provider)
+	for _, p := range providers {
+		providerMap[p.ProviderID] = p
+	}
+
+	// Get A2A endpoints
+	cardCur, err := s.agentCards.Find(ctx, bson.M{"provider_id": bson.M{"$in": providerIDs}})
+	if err != nil {
+		return nil, err
+	}
+	defer cardCur.Close(ctx)
+
+	a2aEndpoints := make(map[string]string)
+	for cardCur.Next(ctx) {
+		var doc agentCardDoc
+		if err := cardCur.Decode(&doc); err == nil {
+			a2aEndpoints[doc.ProviderID] = doc.A2AEndpoint
+		}
+	}
+
+	// Build results
+	results := make([]model.ProviderSearchResult, 0)
+	for providerID, skills := range providerSkills {
+		p, ok := providerMap[providerID]
+		if !ok || p.Status != model.ProviderStatusActive {
+			continue
+		}
+		if p.TrustScore < minTrust {
+			continue
+		}
+
+		matchedTags := make([]string, 0)
+		for tag := range providerTags[providerID] {
+			matchedTags = append(matchedTags, tag)
+		}
+
+		skillIDs := make([]string, 0, len(skills))
+		for _, skill := range skills {
+			skillIDs = append(skillIDs, skill.SkillID)
+		}
+
+		results = append(results, model.ProviderSearchResult{
+			ProviderID:  p.ProviderID,
+			Name:        p.Name,
+			Description: p.Description,
+			Endpoint:    p.Endpoint,
+			A2AEndpoint: a2aEndpoints[providerID],
+			TrustScore:  p.TrustScore,
+			TrustTier:   string(p.TrustTier),
+			Skills:      skillIDs,
+			MatchedTags: matchedTags,
+		})
+
+		if len(results) >= limit {
+			break
+		}
+	}
+
+	return results, nil
+}

--- a/src/aex-provider-registry/internal/store/store.go
+++ b/src/aex-provider-registry/internal/store/store.go
@@ -11,9 +11,15 @@ type Store interface {
 	GetProvider(ctx context.Context, providerID string) (*model.Provider, error)
 	GetProviderByAPIKeyHash(ctx context.Context, apiKeyHash string) (*model.Provider, error)
 	ListProviders(ctx context.Context, providerIDs []string) ([]model.Provider, error)
+	ListAllProviders(ctx context.Context) ([]model.Provider, error)
+	UpdateProvider(ctx context.Context, p model.Provider) error
 
 	CreateSubscription(ctx context.Context, s model.Subscription) error
 	ListSubscriptions(ctx context.Context) ([]model.Subscription, error)
+
+	// A2A support
+	SaveAgentCard(ctx context.Context, providerID string, card model.AgentCard, a2aEndpoint string) error
+	GetProviderWithA2A(ctx context.Context, providerID string) (*model.ProviderWithA2A, error)
+	IndexSkills(ctx context.Context, providerID string, skills []model.SkillIndex) error
+	SearchBySkillTags(ctx context.Context, tags []string, minTrust float64, limit int) ([]model.ProviderSearchResult, error)
 }
-
-

--- a/src/aex-provider-registry/src/main.go
+++ b/src/aex-provider-registry/src/main.go
@@ -42,7 +42,10 @@ func main() {
 		log.Printf("mongo disabled (set MONGO_URI to enable)")
 	}
 
-	svc := service.New(st)
+	svc := service.NewWithOptions(st, cfg.AllowHTTP)
+	if cfg.AllowHTTP {
+		log.Printf("WARNING: HTTP URLs allowed (development mode)")
+	}
 	srv := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      httpapi.NewRouter(svc),

--- a/src/internal/agentcard/resolver.go
+++ b/src/internal/agentcard/resolver.go
@@ -1,0 +1,281 @@
+package agentcard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// WellKnownPath is the standard A2A agent card path
+	WellKnownPath = "/.well-known/agent-card.json"
+	// DefaultCacheTTL is how long to cache agent cards
+	DefaultCacheTTL = 5 * time.Minute
+	// DefaultTimeout for HTTP requests
+	DefaultTimeout = 10 * time.Second
+)
+
+// Resolver fetches and caches A2A Agent Cards
+type Resolver struct {
+	httpClient *http.Client
+	cache      map[string]*cacheEntry
+	cacheMu    sync.RWMutex
+	cacheTTL   time.Duration
+}
+
+type cacheEntry struct {
+	card      *ResolvedAgentCard
+	expiresAt time.Time
+}
+
+// ResolverOption configures the Resolver
+type ResolverOption func(*Resolver)
+
+// WithCacheTTL sets the cache TTL
+func WithCacheTTL(ttl time.Duration) ResolverOption {
+	return func(r *Resolver) {
+		r.cacheTTL = ttl
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client
+func WithHTTPClient(client *http.Client) ResolverOption {
+	return func(r *Resolver) {
+		r.httpClient = client
+	}
+}
+
+// NewResolver creates a new Agent Card resolver
+func NewResolver(opts ...ResolverOption) *Resolver {
+	r := &Resolver{
+		httpClient: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+		cache:    make(map[string]*cacheEntry),
+		cacheTTL: DefaultCacheTTL,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Resolve fetches the agent card from the given base URL
+func (r *Resolver) Resolve(ctx context.Context, baseURL string) (*ResolvedAgentCard, error) {
+	// Normalize URL
+	agentCardURL, err := r.buildAgentCardURL(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	// Check cache
+	if cached := r.getCached(agentCardURL); cached != nil {
+		slog.DebugContext(ctx, "agent card cache hit", "url", agentCardURL)
+		return cached, nil
+	}
+
+	// Fetch from remote
+	slog.InfoContext(ctx, "fetching agent card", "url", agentCardURL)
+	card, err := r.fetch(ctx, agentCardURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	r.setCache(agentCardURL, card)
+
+	return card, nil
+}
+
+// ResolveMultiple fetches agent cards from multiple URLs concurrently
+func (r *Resolver) ResolveMultiple(ctx context.Context, baseURLs []string) ([]*ResolvedAgentCard, []error) {
+	results := make([]*ResolvedAgentCard, len(baseURLs))
+	errors := make([]error, len(baseURLs))
+
+	var wg sync.WaitGroup
+	for i, baseURL := range baseURLs {
+		wg.Add(1)
+		go func(idx int, url string) {
+			defer wg.Done()
+			card, err := r.Resolve(ctx, url)
+			if err != nil {
+				errors[idx] = err
+			} else {
+				results[idx] = card
+			}
+		}(i, baseURL)
+	}
+	wg.Wait()
+
+	return results, errors
+}
+
+// ExtractSkills extracts all skills from an agent card for indexing
+func (r *Resolver) ExtractSkills(card *ResolvedAgentCard, providerID string) []SkillIndex {
+	skills := make([]SkillIndex, 0, len(card.Skills))
+
+	for _, skill := range card.Skills {
+		skills = append(skills, SkillIndex{
+			SkillID:     skill.ID,
+			SkillName:   skill.Name,
+			Description: skill.Description,
+			Tags:        skill.Tags,
+			ProviderID:  providerID,
+			AgentName:   card.Name,
+			AgentURL:    card.URL,
+			A2AEndpoint: r.deriveA2AEndpoint(card.SourceURL),
+		})
+	}
+
+	return skills
+}
+
+// Validate checks if an agent card is valid and well-formed
+func (r *Resolver) Validate(card *AgentCard) error {
+	if card.Name == "" {
+		return fmt.Errorf("agent card missing required field: name")
+	}
+	if card.URL == "" {
+		return fmt.Errorf("agent card missing required field: url")
+	}
+	if len(card.Skills) == 0 {
+		return fmt.Errorf("agent card must have at least one skill")
+	}
+
+	for i, skill := range card.Skills {
+		if skill.ID == "" {
+			return fmt.Errorf("skill %d missing required field: id", i)
+		}
+		if skill.Name == "" {
+			return fmt.Errorf("skill %d missing required field: name", i)
+		}
+	}
+
+	return nil
+}
+
+// InvalidateCache removes a cached agent card
+func (r *Resolver) InvalidateCache(baseURL string) {
+	agentCardURL, err := r.buildAgentCardURL(baseURL)
+	if err != nil {
+		return
+	}
+
+	r.cacheMu.Lock()
+	delete(r.cache, agentCardURL)
+	r.cacheMu.Unlock()
+}
+
+// ClearCache removes all cached agent cards
+func (r *Resolver) ClearCache() {
+	r.cacheMu.Lock()
+	r.cache = make(map[string]*cacheEntry)
+	r.cacheMu.Unlock()
+}
+
+func (r *Resolver) buildAgentCardURL(baseURL string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return "", fmt.Errorf("empty base URL")
+	}
+
+	// If already points to agent-card.json, use as-is
+	if strings.HasSuffix(baseURL, "/agent-card.json") {
+		return baseURL, nil
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Ensure HTTPS in production
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+
+	// Add well-known path
+	u.Path = strings.TrimSuffix(u.Path, "/") + WellKnownPath
+
+	return u.String(), nil
+}
+
+func (r *Resolver) fetch(ctx context.Context, agentCardURL string) (*ResolvedAgentCard, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, agentCardURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "AEX-AgentCardResolver/1.0")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch agent card: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("agent card fetch failed: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var card AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		return nil, fmt.Errorf("decode agent card: %w", err)
+	}
+
+	if err := r.Validate(&card); err != nil {
+		return nil, fmt.Errorf("invalid agent card: %w", err)
+	}
+
+	now := time.Now()
+	resolved := &ResolvedAgentCard{
+		AgentCard:  card,
+		SourceURL:  agentCardURL,
+		ResolvedAt: now,
+		ValidUntil: now.Add(r.cacheTTL),
+	}
+
+	return resolved, nil
+}
+
+func (r *Resolver) getCached(url string) *ResolvedAgentCard {
+	r.cacheMu.RLock()
+	entry, ok := r.cache[url]
+	r.cacheMu.RUnlock()
+
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil
+	}
+
+	return entry.card
+}
+
+func (r *Resolver) setCache(url string, card *ResolvedAgentCard) {
+	r.cacheMu.Lock()
+	r.cache[url] = &cacheEntry{
+		card:      card,
+		expiresAt: time.Now().Add(r.cacheTTL),
+	}
+	r.cacheMu.Unlock()
+}
+
+func (r *Resolver) deriveA2AEndpoint(agentCardURL string) string {
+	// The A2A endpoint is typically at the same host, path /a2a
+	u, err := url.Parse(agentCardURL)
+	if err != nil {
+		return ""
+	}
+	u.Path = "/a2a"
+	return u.String()
+}

--- a/src/internal/agentcard/resolver_test.go
+++ b/src/internal/agentcard/resolver_test.go
@@ -1,0 +1,384 @@
+package agentcard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestResolver_Resolve(t *testing.T) {
+	// Create a test server that serves an agent card
+	agentCard := AgentCard{
+		Name:        "Test Legal Agent",
+		Description: "A test agent for legal tasks",
+		URL:         "https://example.com/agent",
+		Version:     "1.0.0",
+		Provider: &Provider{
+			Organization: "Test Corp",
+			URL:          "https://testcorp.com",
+		},
+		Capabilities: Capabilities{
+			Streaming: true,
+		},
+		Skills: []Skill{
+			{
+				ID:          "contract_review",
+				Name:        "Contract Review",
+				Description: "Review contracts for risks",
+				Tags:        []string{"legal", "contracts"},
+			},
+			{
+				ID:          "legal_research",
+				Name:        "Legal Research",
+				Description: "Research legal precedents",
+				Tags:        []string{"legal", "research"},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/agent-card.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentCard)
+	}))
+	defer server.Close()
+
+	resolver := NewResolver(WithCacheTTL(1 * time.Minute))
+
+	// Test successful resolution
+	card, err := resolver.Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if card.Name != "Test Legal Agent" {
+		t.Errorf("expected name 'Test Legal Agent', got %q", card.Name)
+	}
+
+	if len(card.Skills) != 2 {
+		t.Errorf("expected 2 skills, got %d", len(card.Skills))
+	}
+
+	if card.Skills[0].ID != "contract_review" {
+		t.Errorf("expected first skill ID 'contract_review', got %q", card.Skills[0].ID)
+	}
+}
+
+func TestResolver_ResolveWithCache(t *testing.T) {
+	callCount := 0
+	agentCard := AgentCard{
+		Name:    "Cached Agent",
+		URL:     "https://example.com/agent",
+		Version: "1.0.0",
+		Skills: []Skill{
+			{ID: "skill1", Name: "Skill 1"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentCard)
+	}))
+	defer server.Close()
+
+	resolver := NewResolver(WithCacheTTL(1 * time.Hour))
+
+	// First call - should hit the server
+	_, err := resolver.Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("first resolve failed: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 server call, got %d", callCount)
+	}
+
+	// Second call - should use cache
+	_, err = resolver.Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("second resolve failed: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected still 1 server call (cache hit), got %d", callCount)
+	}
+}
+
+func TestResolver_ResolveMultiple(t *testing.T) {
+	createServer := func(name string) *httptest.Server {
+		agentCard := AgentCard{
+			Name:    name,
+			URL:     "https://example.com/" + name,
+			Version: "1.0.0",
+			Skills: []Skill{
+				{ID: "skill1", Name: "Skill 1"},
+			},
+		}
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(agentCard)
+		}))
+	}
+
+	server1 := createServer("Agent1")
+	server2 := createServer("Agent2")
+	defer server1.Close()
+	defer server2.Close()
+
+	resolver := NewResolver()
+
+	cards, errors := resolver.ResolveMultiple(context.Background(), []string{
+		server1.URL,
+		server2.URL,
+	})
+
+	for i, err := range errors {
+		if err != nil {
+			t.Errorf("resolve %d failed: %v", i, err)
+		}
+	}
+
+	if len(cards) != 2 {
+		t.Errorf("expected 2 cards, got %d", len(cards))
+	}
+
+	if cards[0].Name != "Agent1" {
+		t.Errorf("expected first card name 'Agent1', got %q", cards[0].Name)
+	}
+
+	if cards[1].Name != "Agent2" {
+		t.Errorf("expected second card name 'Agent2', got %q", cards[1].Name)
+	}
+}
+
+func TestResolver_ExtractSkills(t *testing.T) {
+	resolver := NewResolver()
+
+	card := &ResolvedAgentCard{
+		AgentCard: AgentCard{
+			Name: "Legal Agent",
+			URL:  "https://legal.example.com/agent",
+			Skills: []Skill{
+				{
+					ID:          "contract_review",
+					Name:        "Contract Review",
+					Description: "Review contracts",
+					Tags:        []string{"legal", "contracts"},
+				},
+				{
+					ID:          "compliance",
+					Name:        "Compliance Check",
+					Description: "Check compliance",
+					Tags:        []string{"legal", "compliance"},
+				},
+			},
+		},
+		SourceURL: "https://legal.example.com/.well-known/agent-card.json",
+	}
+
+	skills := resolver.ExtractSkills(card, "prov_123")
+
+	if len(skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(skills))
+	}
+
+	if skills[0].SkillID != "contract_review" {
+		t.Errorf("expected skill ID 'contract_review', got %q", skills[0].SkillID)
+	}
+
+	if skills[0].ProviderID != "prov_123" {
+		t.Errorf("expected provider ID 'prov_123', got %q", skills[0].ProviderID)
+	}
+
+	if skills[0].A2AEndpoint != "https://legal.example.com/a2a" {
+		t.Errorf("expected A2A endpoint 'https://legal.example.com/a2a', got %q", skills[0].A2AEndpoint)
+	}
+
+	if len(skills[0].Tags) != 2 || skills[0].Tags[0] != "legal" {
+		t.Errorf("expected tags [legal, contracts], got %v", skills[0].Tags)
+	}
+}
+
+func TestResolver_Validate(t *testing.T) {
+	resolver := NewResolver()
+
+	tests := []struct {
+		name    string
+		card    AgentCard
+		wantErr bool
+	}{
+		{
+			name: "valid card",
+			card: AgentCard{
+				Name:    "Agent",
+				URL:     "https://example.com",
+				Version: "1.0.0",
+				Skills: []Skill{
+					{ID: "skill1", Name: "Skill 1"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			card: AgentCard{
+				URL:     "https://example.com",
+				Version: "1.0.0",
+				Skills: []Skill{
+					{ID: "skill1", Name: "Skill 1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing url",
+			card: AgentCard{
+				Name:    "Agent",
+				Version: "1.0.0",
+				Skills: []Skill{
+					{ID: "skill1", Name: "Skill 1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no skills",
+			card: AgentCard{
+				Name:    "Agent",
+				URL:     "https://example.com",
+				Version: "1.0.0",
+				Skills:  []Skill{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "skill missing id",
+			card: AgentCard{
+				Name:    "Agent",
+				URL:     "https://example.com",
+				Version: "1.0.0",
+				Skills: []Skill{
+					{Name: "Skill 1"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "skill missing name",
+			card: AgentCard{
+				Name:    "Agent",
+				URL:     "https://example.com",
+				Version: "1.0.0",
+				Skills: []Skill{
+					{ID: "skill1"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := resolver.Validate(&tt.card)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolver_InvalidateCache(t *testing.T) {
+	callCount := 0
+	agentCard := AgentCard{
+		Name:    "Agent",
+		URL:     "https://example.com/agent",
+		Version: "1.0.0",
+		Skills: []Skill{
+			{ID: "skill1", Name: "Skill 1"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(agentCard)
+	}))
+	defer server.Close()
+
+	resolver := NewResolver(WithCacheTTL(1 * time.Hour))
+
+	// First call
+	_, _ = resolver.Resolve(context.Background(), server.URL)
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	// Invalidate cache
+	resolver.InvalidateCache(server.URL)
+
+	// Second call - should hit server again
+	_, _ = resolver.Resolve(context.Background(), server.URL)
+	if callCount != 2 {
+		t.Errorf("expected 2 calls after cache invalidation, got %d", callCount)
+	}
+}
+
+func TestResolver_BuildAgentCardURL(t *testing.T) {
+	resolver := NewResolver()
+
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			input:    "https://example.com",
+			expected: "https://example.com/.well-known/agent-card.json",
+			wantErr:  false,
+		},
+		{
+			input:    "https://example.com/",
+			expected: "https://example.com/.well-known/agent-card.json",
+			wantErr:  false,
+		},
+		{
+			input:    "https://example.com/agents/legal",
+			expected: "https://example.com/agents/legal/.well-known/agent-card.json",
+			wantErr:  false,
+		},
+		{
+			input:    "example.com",
+			expected: "https://example.com/.well-known/agent-card.json",
+			wantErr:  false,
+		},
+		{
+			input:    "https://example.com/.well-known/agent-card.json",
+			expected: "https://example.com/.well-known/agent-card.json",
+			wantErr:  false,
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := resolver.buildAgentCardURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildAgentCardURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.expected {
+				t.Errorf("buildAgentCardURL(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/src/internal/agentcard/types.go
+++ b/src/internal/agentcard/types.go
@@ -1,0 +1,70 @@
+package agentcard
+
+import "time"
+
+// AgentCard represents the A2A Agent Card structure
+// Based on https://google.github.io/A2A/specification/
+type AgentCard struct {
+	Name              string            `json:"name"`
+	Description       string            `json:"description"`
+	URL               string            `json:"url"`
+	Provider          *Provider         `json:"provider,omitempty"`
+	Version           string            `json:"version"`
+	DocumentationURL  string            `json:"documentationUrl,omitempty"`
+	Capabilities      Capabilities      `json:"capabilities"`
+	Authentication    *Authentication   `json:"authentication,omitempty"`
+	DefaultInputModes []string          `json:"defaultInputModes,omitempty"`
+	DefaultOutputModes []string         `json:"defaultOutputModes,omitempty"`
+	Skills            []Skill           `json:"skills"`
+}
+
+// Provider represents agent provider information
+type Provider struct {
+	Organization string `json:"organization"`
+	URL          string `json:"url,omitempty"`
+}
+
+// Capabilities represents agent capabilities
+type Capabilities struct {
+	Streaming              bool `json:"streaming,omitempty"`
+	PushNotifications      bool `json:"pushNotifications,omitempty"`
+	StateTransitionHistory bool `json:"stateTransitionHistory,omitempty"`
+}
+
+// Authentication represents authentication requirements
+type Authentication struct {
+	Schemes []string `json:"schemes"`
+	Credentials string `json:"credentials,omitempty"`
+}
+
+// Skill represents an agent skill/capability
+type Skill struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Examples    []string `json:"examples,omitempty"`
+	InputModes  []string `json:"inputModes,omitempty"`
+	OutputModes []string `json:"outputModes,omitempty"`
+}
+
+// ResolvedAgentCard is the internal representation with additional metadata
+type ResolvedAgentCard struct {
+	AgentCard
+	SourceURL   string    `json:"source_url"`
+	ResolvedAt  time.Time `json:"resolved_at"`
+	ValidUntil  time.Time `json:"valid_until"`
+	ProviderID  string    `json:"provider_id,omitempty"`
+}
+
+// SkillIndex represents searchable skill information
+type SkillIndex struct {
+	SkillID     string   `json:"skill_id"`
+	SkillName   string   `json:"skill_name"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+	ProviderID  string   `json:"provider_id"`
+	AgentName   string   `json:"agent_name"`
+	AgentURL    string   `json:"agent_url"`
+	A2AEndpoint string   `json:"a2a_endpoint"`
+}


### PR DESCRIPTION
This commit adds a complete demo showcasing AEX as the discovery layer and A2A protocol for agent-to-agent execution.

Key additions:

Demo Agents:
- Orchestrator: Decomposes tasks, discovers providers via AEX, executes via A2A
- Legal Agent A (Budget): $5 + $2/page, contract review
- Legal Agent B (Standard): $15 + $0.50/page, compliance check
- Legal Agent C (Premium): $30 + $0.20/page, negotiation support
- All agents use Claude (Anthropic) as the LLM backend

AEX Provider Registry Enhancements:
- Add HTTP URL support for development mode (ENVIRONMENT=development)
- Add capabilities-based provider search in MongoDB store
- Add NewWithOptions constructor for configurable URL validation
- Support skill tag matching for provider discovery

Infrastructure:
- Docker Compose setup with all AEX services and demo agents
- Agent Card resolver for A2A protocol compliance
- Common A2A server implementation for Python agents
- GCP Cloud Run deployment configuration

Documentation:
- Complete call flow documentation (DEMO_CALL_FLOW.md)
- PlantUML sequence diagrams for all integration flows
- Integration roadmap and implementation plan
- Value proposition document

The demo flow:
1. Agents register with AEX on startup (capabilities-based)
2. User sends request to Orchestrator via A2A
3. Orchestrator calls Claude to decompose into subtasks
4. Orchestrator queries AEX /v1/providers/search for each skill
5. Orchestrator sends A2A requests directly to selected agents
6. Results are aggregated and returned to user